### PR TITLE
Refs #15: First line of markdown not rendered right

### DIFF
--- a/symposion/templates/boxes/box.html
+++ b/symposion/templates/boxes/box.html
@@ -33,9 +33,7 @@
     {% if form %}
         <a href="#edit_{{ label }}" data-toggle="modal" class="btn edit-toggle"><i class="icon-pencil"></i> Edit this content</a>
     {% endif %}
-    <div class="markdown">
-        {{ box.content|safe }}
-    </div>
+    <div class="markdown">{{ box.content|safe }}</div>
 </div>
 
 

--- a/symposion/templates/cms/page_detail.html
+++ b/symposion/templates/cms/page_detail.html
@@ -29,6 +29,4 @@
 
 {% block breadcrumbs %}{% sitetree_breadcrumbs from "main" %}{% endblock %}
 
-{% block body %}
-    {{ page.body }}
-{% endblock %}
+{% block body %}{{ page.body }}{% endblock %}

--- a/symposion/templates/site_base.html
+++ b/symposion/templates/site_base.html
@@ -75,10 +75,7 @@
                 </div>
                 <div class="span9">
                     <div class="box">
-                        <div class="box-content">
-                            {% block body %}
-                            {% endblock %}
-                        </div>
+                        <div class="box-content">{% block body %}{% endblock %}</div>
                     </div>
                 </div>
                 <div class="span3">


### PR DESCRIPTION
Just had to remove some whitespace from the templates that was
making it think the first line was an indented block.
