### PR TITLE
Link to standard Markdown cheatsheet

### DIFF
--- a/symposion/speakers/models.py
+++ b/symposion/speakers/models.py
@@ -15,7 +15,7 @@ class Speaker(models.Model):
 
     user = models.OneToOneField(User, null=True, related_name="speaker_profile")
     name = models.CharField(max_length=100, help_text="As you would like it to appear in the conference program.")
-    biography = models.TextField(help_text="A little bit about you. Edit using <a href='http://warpedvisions.org/projects/markdown-cheat-sheet/' target='_blank'>Markdown</a>.")
+    biography = models.TextField(help_text="A little bit about you. Edit using <a href='http://daringfireball.net/projects/markdown/basics' target='_blank'>Markdown</a>.")
     photo = models.ImageField(upload_to="speaker_photos", blank=True)
     twitter_username = models.CharField(
         max_length = 15,


### PR DESCRIPTION
Instead of the one that was being linked to, that described
a bunch of extensions to Markdown that MarkEdit does not support.

This is one of the bugs from #15.
