### PR TITLE
Allow dashes in proposal kind slugs

### DIFF
--- a/symposion/proposals/urls.py
+++ b/symposion/proposals/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns, url
 
 
 urlpatterns = patterns("symposion.proposals.views",
     url(r"^submit/$", "proposal_submit", name="proposal_submit"),
-    url(r"^submit/(\w+)/$", "proposal_submit_kind", name="proposal_submit_kind"),
+    url(r"^submit/([\w-]+)/$", "proposal_submit_kind", name="proposal_submit_kind"),
     url(r"^(\d+)/$", "proposal_detail", name="proposal_detail"),
     url(r"^(\d+)/edit/$", "proposal_edit", name="proposal_edit"),
     url(r"^(\d+)/speakers/$", "proposal_speaker_manage", name="proposal_speaker_manage"),


### PR DESCRIPTION
We can see from the setting PROPOSAL_FORMS that at least one proposal kind, 
Sponsor Tutorial, has a slug with a dash in it: sponsor-tutorial. Yet the URL
pattern for submitting a proposal doesn't accept dashes in the slug. Fix it.
