### PR TITLE
Fix preview width and add label

### DIFF
--- a/markedit/static/css/jquery.markedit.css
+++ b/markedit/static/css/jquery.markedit.css
@@ -1,5 +1,5 @@
 .markedit { clear: both; }
-.markedit textarea { width: 100%; }
+.markedit textarea, .markedit-preview { width: 100%; }
 
 .markedit-toolbar { padding: 0.3em; margin: 0; clear: both; height: 22px; border-radius: 8px 8px 0px 0px; -moz-border-radius: 8px 8px 0px 0px;}
 .markedit-toolbar .toolbar-group { margin-right: 0.5em; padding: 0 0 0 5px; float: left; }

--- a/markedit/static/js/jquery.markedit.js
+++ b/markedit/static/js/jquery.markedit.js
@@ -309,7 +309,9 @@
 
             // Create preview pane
             if (options.preview !== false) {
-                var previewPane = $('<div class="markedit-preview ui-widget-content"></div>');
+                var previewId = $(this).attr('id') + '-preview';
+                var label = $('<label for="' + previewId + '">Preview:</label>');
+                var previewPane = $('<div class="markedit-preview ui-widget-content" id="' + previewId + '"></div>');
 
                 // Set initial state for preview if enabled (now that it's created)
                 if (options.preview === 'toolbar') {
@@ -326,6 +328,7 @@
                 }
                 else if (options.preview === 'bottom' || options.preview === 'below') {
 
+                    $(parent).append(label);
                     $(parent).append(previewPane);
                     $(previewPane).addClass('bottom-preview');
                     $(this).markeditBindAutoPreview(previewPane);
@@ -334,6 +337,7 @@
                 else if (options.preview === 'top' || options.preview === 'above') {
 
                     $(parent).prepend(previewPane);
+                    $(parent).prepend(label);
                     $(previewPane).addClass('top-preview');
                     $(this).markeditBindAutoPreview(previewPane);
 


### PR DESCRIPTION
- Make the preview area the same width as the editing area
- Add a "Preview" label above the preview area. Right now it
  just looks like the other labels on the form; we might want
  to style it a little differently but I'll leave that to
  @juliaelman.

This addresses part of #15.
