### PR TITLE
HTML in CMS

### DIFF
--- a/symposion/templates/cms/page_detail.html
+++ b/symposion/templates/cms/page_detail.html
@@ -29,4 +29,4 @@
 
 {% block breadcrumbs %}{% sitetree_breadcrumbs from "main" %}{% endblock %}
 
-{% block body %}{{ page.body }}{% endblock %}
+{% block body %}{{ page.body|safe }}{% endblock %}


### PR DESCRIPTION
Some CMS pages appear to have been entered as HTML instead of markdown - e.g. /2014/about/what-is-pycon/

These look okay in the preview in the admin, but on the site they're getting rendered as raw HTML and look awful.

We need to figure out if there are more than a handful of these. If not, we can just fix them manually. Otherwise we'll need to fix the rendering or fix them automatically or something.
