### PR TITLE
User names in user picklists

### DIFF
--- a/pycon/admin.py
+++ b/pycon/admin.py
@@ -72,3 +72,14 @@ admin.site.register(PyConTalkProposal, TalkAdmin)
 admin.site.register(PyConTutorialProposal, TutorialAdmin)
 admin.site.register(PyConPosterProposal, PosterAdmin)
 admin.site.register(PyConSponsorTutorialProposal, SponsorTutorialAdmin)
+
+
+# HACK HACK - monkey patch User because the username field is useless
+# when using django-user-accounts
+from django.contrib.auth.models import User
+
+
+def user_unicode(self):
+    # Use full name if any, else email
+    return self.get_full_name() or self.email
+User.__unicode__ = user_unicode


### PR DESCRIPTION
Typically the `username` assigned when someone signs up is a long hex string, and that's what shows up when another model has a foreign key to a user (see e.g. the Box model in the admin and trying to change the 'created by' field to another user).  Let's try to get that to show up as the name and/or email addr.
