### PR TITLE
Change from PIL to Pillow

### DIFF
--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -6,7 +6,7 @@
 # Put project-specific requirements here.
 # See http://pip-installer.org/requirement-format.html for more information.
 
-PIL==1.1.6
+Pillow==2.0.0
 easy-thumbnails==1.2
 html5lib==0.95
 django-social-auth==0.7.23


### PR DESCRIPTION
PIL seems to be unavailable.  That might be temporary due to effbot.org being down, but Pillow is a workable alternative that'll get us going again.
