### PR TITLE
Logging?

### DIFF
--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -24,3 +24,5 @@ django-redis-cache==0.9.7
 redis==2.7.5
 hiredis==0.1.1
 South==0.8.1
+
+graypy==0.2.9


### PR DESCRIPTION
Right now, stdout and stderr from Django go to supervisor logs under /var/log/supervisor, with the default log levels.

Do we want to update the Django log config to redirect those messages to a django log file?
