### PR TITLE
use correct protocol for 3rd party assets

### DIFF
--- a/pycon/static/less/site.less
+++ b/pycon/static/less/site.less
@@ -25,7 +25,7 @@
 
 /* Fonts
 ==================== */
-@import url(http://fonts.googleapis.com/css?family=Lato:400,400italic,700,900);
+@import url(//fonts.googleapis.com/css?family=Lato:400,400italic,700,900);
 
 /* Variables
 ==================== */

--- a/pycon/templates/site_base.html
+++ b/pycon/templates/site_base.html
@@ -38,7 +38,7 @@
 {% block extra_head_base %}
     <meta property="og:image" content="https://us.pycon.org/2014/site_media/static/img/logo.png" />
     <link href="{{ STATIC_URL }}img/favicon.ico" rel="shortcut icon" />
-    <script src="http://code.jquery.com/jquery-1.8.3.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
     {% include "markedit/includes/markedit-js.html" %}
     {% block extra_head %}{% endblock %}
     <meta name="google-site-verification" content="fG_DG4G4eFtBcgIKht-bJKdirGhDa_51X6yeCS8daDs" />

--- a/symposion/templates/site_base.html
+++ b/symposion/templates/site_base.html
@@ -38,7 +38,7 @@
 {% block extra_head_base %}
     <meta property="og:image" content="https://us.pycon.org/2014/site_media/static/img/logo.png" />
     <link href="{{ STATIC_URL }}img/favicon.ico" rel="shortcut icon" />
-    <script src="http://code.jquery.com/jquery-1.8.3.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
     {% include "markedit/includes/markedit-js.html" %}
     {% block extra_head %}{% endblock %}
     <meta name="google-site-verification" content="fG_DG4G4eFtBcgIKht-bJKdirGhDa_51X6yeCS8daDs" />


### PR DESCRIPTION
this change allows for jQuery and google font to be requested over whichever protocol the user requests the page from.

in some browsers these 3rd party assets are silently ignored when the page is accessed via HTTPS, while their protocol is HTTP
