### PR TITLE
Replace 'REGISTER TODAY' with 'Reg Fall 2013'

### DIFF
--- a/pycon/templates/homepage.html
+++ b/pycon/templates/homepage.html
@@ -25,8 +25,13 @@
                             <time itemprop="endDate" datetime="2014-4-17">17</time>
                         </div>
                     </div>
+                    {% comment %}
                     <div class="span5 promo" itemprop="tickets" itemscope itemtype="http://data-vocabulary.org/Offer">
                         <a href="#">REGISTER TODAY!</a>
+                    </div>
+                    {% endcomment %}
+                    <div class="span5 promo">
+                        <a>Register Fall 2013</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
We'll need this done before launch. Has been ok'd by @dianaclarke.
