### PR TITLE
Tweaks to proposal submission fields

### DIFF
--- a/pycon/forms.py
+++ b/pycon/forms.py
@@ -44,9 +44,14 @@ class PyConTalkProposalForm(PyConProposalForm):
             "recording_release",
         ]
         widgets = {
+            "title": forms.TextInput(attrs={'class': 'fullwidth-input'}),
+            "description": forms.Textarea(attrs={'rows': '3'}),
+            "audience": forms.TextInput(attrs={'class': 'fullwidth-input'}),
+            "perceived_value": forms.Textarea(attrs={'rows': '3'}),
             "abstract": MarkEdit(),
-            "additional_notes": MarkEdit(),
             "outline": MarkEdit(),
+            "additional_notes": MarkEdit(attrs={'rows': '3'}),
+            "additional_requirements": forms.Textarea(attrs={'rows': '3'}),
         }
 
 
@@ -72,7 +77,10 @@ class PyConLightningTalkProposalForm(PyConProposalForm):
             "audience_level",
         ]
         widgets = {
-            "additional_notes": MarkEdit(),
+            "title": forms.TextInput(attrs={'class': 'fullwidth-input'}),
+            "description": forms.Textarea(attrs={'rows': '3'}),
+            "additional_notes": MarkEdit(attrs={'rows': '3'}),
+            "additional_requirements": forms.Textarea(attrs={'rows': '3'}),
         }
 
 
@@ -97,10 +105,15 @@ class PyConTutorialProposalForm(PyConProposalForm):
 
         ]
         widgets = {
+            "title": forms.TextInput(attrs={'class': 'fullwidth-input'}),
+            "description": forms.Textarea(attrs={'rows': '3'}),
+            "audience": forms.TextInput(attrs={'class': 'fullwidth-input'}),
+            "perceived_value": forms.Textarea(attrs={'rows': '3'}),
             "abstract": MarkEdit(),
             "outline": MarkEdit(),
             "more_info": MarkEdit(),
-            "additional_notes": MarkEdit(),
+            "additional_notes": MarkEdit(attrs={'rows': '3'}),
+            "additional_requirements": forms.Textarea(attrs={'rows': '3'}),
         }
 
 
@@ -120,8 +133,11 @@ class PyConPosterProposalForm(PyConProposalForm):
 
         ]
         widgets = {
+            "title": forms.TextInput(attrs={'class': 'fullwidth-input'}),
+            "description": forms.Textarea(attrs={'rows': '3'}),
             "abstract": MarkEdit(),
-            "additional_notes": MarkEdit(),
+            "additional_notes": MarkEdit(attrs={'rows': '3'}),
+            "additional_requirements": forms.Textarea(attrs={'rows': '3'}),
         }
 
 
@@ -136,6 +152,8 @@ class PyConSponsorTutorialForm(PyConProposalForm):
             "additional_notes",
         ]
         widgets = {
+            "title": forms.TextInput(attrs={'class': 'fullwidth-input'}),
+            "description": forms.Textarea(attrs={'rows': '3'}),
             "abstract": MarkEdit(),
-            "additional_notes": MarkEdit(),
+            "additional_notes": MarkEdit(attrs={'rows': '3'}),
         }

--- a/pycon/models.py
+++ b/pycon/models.py
@@ -117,7 +117,7 @@ class PyConTalkProposal(PyConProposal):
     )
     perceived_value = models.TextField(
         _(u"Objectives"),
-        max_length=500,
+        max_length=400,
         help_text=_(u"What will attendees get out of your talk? When they "
                     u"leave the room, what will they know that they didn't "
                     u"know before?"),

--- a/pycon/static/less/site.less
+++ b/pycon/static/less/site.less
@@ -233,6 +233,10 @@ input[type="submit"],
   .control-group & { margin-bottom: 0; }
 }
 
+input.fullwidth-input {
+  width: 600px;
+}
+
 // Textarea
 textarea {
   height: auto;


### PR DESCRIPTION
Requested by Luke:

_Audience Field_
On the form fields for talk submission, there's a field that I asked for called "audience". I asked for it to be short answer, and I see this is done. Thank you! 

The size of the box is a bit too short of an answer. Can that box be made to span the full line (make it equal in width to "objectives", below?) 

I don't want to get a paragraph, but I want more than one word. :-)

A couple more items, along the same vein: 
- I would like the "title" field width to match my request for the "audience" field width, above.
- The "description" field is far too long, especially since we asked for a 400 character maximum. Can we make it have a height equal to three lines of text? (Right now it's about 8 lines...)
- "Objectives": same as description. Also, can we add a 400 characters notice/restriction, just like "description"? This should be two or three sentences, not an essay.
- Can we make both of the last two fields ("additional notes", "additional requirements") also be three lines high? They don't need to have 400 character restrictions; they just need to be smaller.
