### PR TITLE
Duplicate memberships

### DIFF
--- a/symposion/teams/migrations/0002_auto__add_unique_membership_user_team.py
+++ b/symposion/teams/migrations/0002_auto__add_unique_membership_user_team.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding unique constraint on 'Membership', fields ['user', 'team']
+        db.create_unique(u'teams_membership', ['user_id', 'team_id'])
+
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'Membership', fields ['user', 'team']
+        db.delete_unique(u'teams_membership', ['user_id', 'team_id'])
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'teams.membership': {
+            'Meta': {'unique_together': "(('user', 'team'),)", 'object_name': 'Membership'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'team': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'memberships'", 'to': u"orm['teams.Team']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'memberships'", 'to': u"orm['auth.User']"})
+        },
+        u'teams.team': {
+            'Meta': {'object_name': 'Team'},
+            'access': ('django.db.models.fields.CharField', [], {'max_length': '20'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'manager_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'manager_teams'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "'member_teams'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'})
+        }
+    }
+
+    complete_apps = ['teams']

--- a/symposion/teams/models.py
+++ b/symposion/teams/models.py
@@ -72,5 +72,8 @@ class Membership(models.Model):
     state = models.CharField(max_length=20, choices=MEMBERSHIP_STATE_CHOICES)
     message = models.TextField(blank=True)
 
+    class Meta:
+        unique_together = ('user', 'team')
+
 
 reversion.register(Membership)


### PR DESCRIPTION
Seeing this on staging:

Traceback (most recent call last):

  File "/srv/staging-pycon.python.org/shared/env/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 115, in get_response
    response = callback(request, _callback_args, *_callback_kwargs)

  File "/srv/staging-pycon.python.org/shared/env/local/lib/python2.7/site-packages/django/contrib/auth/decorators.py", line 25, in _wrapped_view
    return view_func(request, _args, *_kwargs)

  File "/srv/staging-pycon.python.org/releases/952b082533e841b6522bb27d257c949638d62671/symposion/teams/views.py", line 59, in team_detail
    state = team.get_state_for_user(request.user)

  File "/srv/staging-pycon.python.org/releases/952b082533e841b6522bb27d257c949638d62671/symposion/teams/models.py", line 41, in get_state_for_user
    return self.memberships.get(user=user).state

  File "/srv/staging-pycon.python.org/shared/env/local/lib/python2.7/site-packages/django/db/models/manager.py", line 143, in get
    return self.get_query_set().get(_args, *_kwargs)

  File "/srv/staging-pycon.python.org/shared/env/local/lib/python2.7/site-packages/django/db/models/query.py", line 393, in get
    (self.model._meta.object_name, num, kwargs))

MultipleObjectsReturned: get() returned more than one Membership -- it returned 2! Lookup parameters were {'user': <django.utils.functional.SimpleLazyObject object at 0x3591790>}

It looks like:
- Membership needs to be unique on (user, team)
- We need to figure out where the dupes are getting created
- We need to fix the data.
