### PR TITLE
Proposal Submission Form CMS Box should discriminate by Proposal Kind/Type

### DIFF
--- a/pycon/templates/proposals/proposal_submit_kind.html
+++ b/pycon/templates/proposals/proposal_submit_kind.html
@@ -9,7 +9,7 @@
 
 {% block body %}
     <div class="span12">
-        {% box "example_proposal" %}
+        {% box kind.slug|add:"-proposal" %}
         <form method="POST" action="" enctype="multipart/form-data" class="form-horizontal">
             {% csrf_token %}
             <fieldset>


### PR DESCRIPTION
Fixes #134 
- Modify the naming schema of the CMS Box to be explicit for each ProposalKind.
