### PR TITLE
Small Copy Change on the Talk Submission Interface.

### DIFF
--- a/pycon/models.py
+++ b/pycon/models.py
@@ -112,9 +112,7 @@ class PyConTalkProposal(PyConProposal):
     duration = models.IntegerField(choices=DURATION_CHOICES)
 
     outline = models.TextField(
-        _("Outline"),
-        help_text=_("Detailed outline. Will be made public "
-                    "if your talk is accepted.")
+        _("Outline")
     )
     audience = models.CharField(
         max_length=150,
@@ -157,9 +155,7 @@ class PyConTutorialProposal(PyConProposal):
                     'presentation\'s domain.'))
 
     outline = models.TextField(
-        _("Outline"),
-        help_text=_("Detailed outline. Will be made public "
-                    "if your talk is accepted.")
+        _("Outline")
     )
     more_info = models.TextField(
         _("More info"),


### PR DESCRIPTION
Luke Sneeringer posted this message on Basecamp.
Small Copy Change on the Talk Submission Interface.
Right now, under the "outline" field, it says:
"Detailed outline. Will be made public if your talk is accepted."

Please remove this copy altogether. We don't traditionally make outlines public. 
