### PR TITLE
Set open period for financial aid applications in the database

### DIFF
--- a/docs/finaid.rst
+++ b/docs/finaid.rst
@@ -7,30 +7,10 @@ Settings
 Create a FINANCIAL_AID setting in Django settings. It should be a dictionary.
 Values can include:
 
-    start_date
-        (datetime object) If set, financial aid applications will not be
-        accepted or allowed to be edited before this date.
-    end_date
-        (datetime object) If set, financial aid applications will not be
-        accepted or allowed to be edited after this date.
     email
         The email address that messages related to financial aid come from,
         and that users should email with questions. Defaults to
         ``pycon-aid@pycon.org``.
-
-If neither start_date or end_date is set, applications are closed.
-
-So if you wanted the application period to be July, 2013, you would set:
-
-.. code-block:: python
-
-    import datetime
-
-    FINANCIAL_AID = {
-        'start_date': datetime.datetime(2013, 7, 1),
-        'end_date': datetime.datetime(2013, 7, 31, 23, 59, 59),
-    }
-
 
 Add the context processor:
 
@@ -39,6 +19,10 @@ Add the context processor:
         "pycon.finaid.context_processors.financial_aid",
         ...
     ]
+
+To enable applications, use the admin to create new
+FinancialAidApplicationPeriod records with the desired start
+and end dates.
 
 
 Templates

--- a/pycon/finaid/admin.py
+++ b/pycon/finaid/admin.py
@@ -1,9 +1,7 @@
 from django.contrib import admin
 
-from .models import FinancialAidApplication, FinancialAidMessage
-
-
-admin.site.register(FinancialAidApplication)
+from .models import FinancialAidApplication, FinancialAidApplicationPeriod,\
+    FinancialAidMessage
 
 
 def application__user(message):
@@ -15,4 +13,6 @@ class MessageAdmin(admin.ModelAdmin):
     list_display = ('submitted_at', 'user', application__user)
 
 
+admin.site.register(FinancialAidApplication)
+admin.site.register(FinancialAidApplicationPeriod)
 admin.site.register(FinancialAidMessage, MessageAdmin)

--- a/pycon/finaid/migrations/0003_auto__add_financialaidapplicationperiod.py
+++ b/pycon/finaid/migrations/0003_auto__add_financialaidapplicationperiod.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'FinancialAidApplicationPeriod'
+        db.create_table(u'finaid_financialaidapplicationperiod', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('start', self.gf('django.db.models.fields.DateTimeField')()),
+            ('end', self.gf('django.db.models.fields.DateTimeField')()),
+        ))
+        db.send_create_signal(u'finaid', ['FinancialAidApplicationPeriod'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'FinancialAidApplicationPeriod'
+        db.delete_table(u'finaid_financialaidapplicationperiod')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'finaid.financialaidapplication': {
+            'Meta': {'object_name': 'FinancialAidApplication'},
+            'beginner_resources': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'experience_level': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'first_time': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'hotel_grant_requested': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'hotel_nights': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'international': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'involvement': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'blank': 'True'}),
+            'last_update': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'portfolios': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'presented': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'presenting': ('django.db.models.fields.IntegerField', [], {}),
+            'profession': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'pyladies_grant_requested': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'registration_grant_requested': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'sex': ('django.db.models.fields.IntegerField', [], {'default': '0', 'blank': 'True'}),
+            'status': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'travel_amount_requested': ('django.db.models.fields.DecimalField', [], {'default': "'0.00'", 'max_digits': '8', 'decimal_places': '2'}),
+            'travel_grant_requested': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'travel_plans': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'blank': 'True'}),
+            'tutorial_grant_requested': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'use_of_python': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'financial_aid'", 'unique': 'True', 'to': u"orm['auth.User']"}),
+            'want_to_learn': ('django.db.models.fields.CharField', [], {'max_length': '500'}),
+            'what_you_want': ('django.db.models.fields.CharField', [], {'max_length': '500'})
+        },
+        u'finaid.financialaidapplicationperiod': {
+            'Meta': {'object_name': 'FinancialAidApplicationPeriod'},
+            'end': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'start': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        u'finaid.financialaidmessage': {
+            'Meta': {'ordering': "['submitted_at']", 'object_name': 'FinancialAidMessage'},
+            'application': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'messages'", 'to': u"orm['finaid.FinancialAidApplication']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'submitted_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"}),
+            'visible': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        }
+    }
+
+    complete_apps = ['finaid']

--- a/pycon/finaid/models.py
+++ b/pycon/finaid/models.py
@@ -151,3 +151,18 @@ class FinancialAidMessage(models.Model):
         Typically you'd filter this further on a particular application
         or something."""
         return cls.objects.exclude(seen__user=user)
+
+
+class FinancialAidApplicationPeriod(models.Model):
+    """Represents periods when applications are open"""
+    start = models.DateTimeField()
+    end = models.DateTimeField()
+
+    @classmethod
+    def open(cls):
+        """Return True if applications are open right now"""
+        now = datetime.datetime.now()
+        return bool(cls._default_manager.filter(start__lt=now, end__gt=now))
+
+    def __unicode__(self):
+        return u"Applications open %s-%s" % (self.start, self.end)

--- a/pycon/finaid/utils.py
+++ b/pycon/finaid/utils.py
@@ -1,10 +1,10 @@
-import datetime
-
 from django.conf import settings
 from django.core.mail import send_mail
 from django.template import Context
 from django.template.loader import get_template
-from pycon.finaid.models import FinancialAidApplication
+from pycon.finaid.models import FinancialAidApplication, \
+    FinancialAidApplicationPeriod
+
 
 DEFAULT_EMAIL_ADDRESS = "pycon-aid@pycon.org"
 
@@ -13,32 +13,10 @@ def applications_open():
     """Return True if applications are allowed to be submitted
      and edited at the current time.
 
-    Based on settings.FINANCIAL_AID['start_date'] and ['end_date']:
-
-
-    start_date
-        (datetime object) If set, financial aid applications will not be
-        accepted or allowed to be edited before this date.
-    end_date
-        (datetime object) If set, financial aid applications will not be
-        accepted or allowed to be edited after this date
-
-    If neither is set, applications are closed.
+    Based on there being a FinancialAidApplicationPeriod record
+    encompassing the current time.
     """
-    now = datetime.datetime.now()
-    if hasattr(settings, "FINANCIAL_AID"):
-        finaid_settings = settings.FINANCIAL_AID
-    else:
-        finaid_settings = {}
-    start_date = finaid_settings.get('start_date', None)
-    end_date = finaid_settings.get('end_date', None)
-    if not start_date and not end_date:
-        return False
-    if start_date and now < start_date:
-        return False
-    if end_date and end_date < now:
-        return False
-    return True
+    return FinancialAidApplicationPeriod.open()
 
 
 def is_reviewer(user):


### PR DESCRIPTION
Instead of a setting, control the open period for financial aid applications
using the database.

This is mainly because we want to be able to enable applications on staging
for testing without enabling them in production, though it also means pycon
organizers can control the period more easily.
