### PR TITLE
Escape messages; add form error message

### DIFF
--- a/pycon/templates/finaid/edit.html
+++ b/pycon/templates/finaid/edit.html
@@ -16,6 +16,13 @@
     <form method="POST" action="" enctype="multipart/form-data" class="form-horizontal">
         {% csrf_token %}
         <legend>{% if applying %}{% trans "Apply for Financial Aid" %}{% else %}{% trans "Edit Financial Aid Application" %}{% endif %}</legend>
+
+        {% if form.errors and not form.non_field_errors %}
+          <div class="alert alert-error">
+            {% blocktrans count counter=form.errors.items|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktrans %}
+          </div>
+        {% endif %}
+
         {{ form|as_bootstrap }}
         <div class="form-actions">
             <input class="btn btn-success" type="submit" value="{% if applying %}{% trans "Apply" %}{% else %}{% trans "Submit" %}{% endif %}" />

--- a/pycon/templates/finaid/status.html
+++ b/pycon/templates/finaid/status.html
@@ -32,7 +32,7 @@
               {# Note: these are only the messages that are visible to the applicant #}
               {% for message in visible_messages %}
                   <div class="review-box">
-                      <div class="comment">{{ message.message|safe }}</div>
+                      <div class="comment">{{ message.message|escape }}</div>
                       <div class="dateline"><b>{% user_display message.user %}</b> {{ message.submitted_at|timesince }} ago</div>
                   </div>
                   <div class="clear"></div>


### PR DESCRIPTION
- When displaying financial aid application messages, escape the text
  for security.
- If there's an error on the financial aid application form, display a
  message at the top so it's more obvious.
