### PR TITLE
Get rid of financial aid context processor

### DIFF
--- a/symposion/settings.py
+++ b/symposion/settings.py
@@ -144,7 +144,6 @@ TEMPLATE_CONTEXT_PROCESSORS = [
     "pinax_utils.context_processors.settings",
     "account.context_processors.account",
     "symposion.reviews.context_processors.reviews",
-    "pycon.finaid.context_processors.financial_aid",
 ]
 
 INSTALLED_APPS = [

--- a/symposion/views.py
+++ b/symposion/views.py
@@ -8,6 +8,7 @@ from django.contrib.auth.decorators import login_required
 
 import account.views
 
+from pycon.finaid.context_processors import financial_aid
 import symposion.forms
 from symposion.proposals.models import ProposalSection
 
@@ -49,7 +50,9 @@ def dashboard(request):
     if request.session.get("pending-token"):
         return redirect("speaker_create_token",
                         request.session["pending-token"])
+    context = {'proposals_are_open': bool(ProposalSection.available()), }
+    context.update(financial_aid(request))
     return render(
         request, "dashboard.html",
-        {'proposals_are_open': bool(ProposalSection.available()), },
+        context,
     )


### PR DESCRIPTION
Financial aid has a context processor that runs on every view, but the only view that really needs it is the dashboard. We should be able to save a few queries on most views by only doing that processing when we need to.  Maybe use template tags or something. All it's doing is figuring out whether to display the financial aid section on the dashboard, and which buttons to display inside it.
