### PR TITLE
Fix message count in finaid status

### DIFF
--- a/pycon/templates/finaid/status.html
+++ b/pycon/templates/finaid/status.html
@@ -18,7 +18,7 @@
     <div class="tabbable">
         <ul class="nav nav-tabs">
             <li class="active"><a href="#application-detail" data-toggle="tab">{% trans "Proposal Details" %}</a></li>
-            <li><a href="#application-feedback" data-toggle="tab">{% trans "Reviewer Feedback" %} <span class="badge">{{ application.messages.all|length }}</span></a></li>
+            <li><a href="#application-feedback" data-toggle="tab">{% trans "Reviewer Feedback" %} <span class="badge">{{ visible_messages|length }}</span></a></li>
         </ul>
 
         <div class="tab-content">


### PR DESCRIPTION
On the financial aid application status page, the messages tag was showing the
count of all messages, instead of the count of messages that are visible to
the user. Fix.
