### PR TITLE
Enforce data types attached to sponsor benefits

### DIFF
--- a/pycon/sponsorship/admin.py
+++ b/pycon/sponsorship/admin.py
@@ -60,6 +60,10 @@ class SponsorAdmin(admin.ModelAdmin):
 class BenefitAdmin(admin.ModelAdmin):
 
     inlines = [BenefitLevelInline]
+    list_display = ('name', 'type', 'levels')
+
+    def levels(self, benefit):
+        return u", ".join(l.level.name for l in benefit.benefit_levels.all())
 
 
 class SponsorLevelAdmin(admin.ModelAdmin):

--- a/pycon/sponsorship/tests.py
+++ b/pycon/sponsorship/tests.py
@@ -6,6 +6,7 @@ from zipfile import ZipFile
 
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test.utils import override_settings
@@ -135,3 +136,78 @@ class TestSponsorZipDownload(TestCase):
             if hasattr(self, 'temp_dir'):
                 # Clean up any temp media files
                 shutil.rmtree(self.temp_dir)
+
+
+class TestBenefitValidation(TestCase):
+    """
+    It should not be possible to save a SponsorBenefit if it has the
+    wrong kind of data in it - e.g. a text-type benefit cannot have
+    an uploaded file, and vice-versa.
+    """
+    def setUp(self):
+        # we need a sponsor
+        conference = current_conference()
+        self.sponsor_level = SponsorLevel.objects.create(
+            conference=conference, name="Lead", cost=1)
+        self.sponsor = Sponsor.objects.create(
+            name="Big Daddy",
+            level=self.sponsor_level,
+        )
+
+        # Create our benefit types
+        self.text_type = Benefit.objects.create(name="text", type="text")
+        self.file_type = Benefit.objects.create(name="file", type="file")
+        self.weblogo_type = Benefit.objects.create(name="log", type="weblogo")
+        self.simple_type = Benefit.objects.create(name="simple", type="simple")
+
+    def validate(self, should_work, benefit_type, upload, text):
+        obj = SponsorBenefit(
+            benefit=benefit_type,
+            sponsor=self.sponsor,
+            upload=upload,
+            text=text
+        )
+        if should_work:
+            obj.save()
+        else:
+            with self.assertRaises(ValidationError):
+                obj.save()
+
+    def test_text_has_text(self):
+        self.validate(True, self.text_type, upload=None, text="Some text")
+
+    def test_text_has_upload(self):
+        self.validate(False, self.text_type, upload="filename", text='')
+
+    def test_text_has_both(self):
+        self.validate(False, self.text_type, upload="filename", text="Text")
+
+    def test_file_has_text(self):
+        self.validate(False, self.file_type, upload=None, text="Some text")
+
+    def test_file_has_upload(self):
+        self.validate(True, self.file_type, upload="filename", text='')
+
+    def test_file_has_both(self):
+        self.validate(False, self.file_type, upload="filename", text="Text")
+
+    def test_weblogo_has_text(self):
+        self.validate(False, self.weblogo_type, upload=None, text="Some text")
+
+    def test_weblogo_has_upload(self):
+        self.validate(True, self.weblogo_type, upload="filename", text='')
+
+    def test_weblogo_has_both(self):
+        self.validate(False, self.weblogo_type, upload="filename", text="Text")
+
+    def test_simple_has_neither(self):
+        self.validate(True, self.simple_type, upload=None, text='')
+
+    def test_simple_has_text(self):
+        self.validate(True, self.simple_type, upload=None, text="Some text")
+
+    def test_simple_has_upload(self):
+        self.validate(False, self.simple_type, upload="filename", text='')
+
+    def test_simple_has_both(self):
+        self.validate(False, self.simple_type, upload="filename", text="Text")


### PR DESCRIPTION
The SponsorBenefit model doesn't represent in any way that logos have to have uploads while some other benefit types have to have text. Llook into what we can do in the admin to help enforce that when people are editing a benefit, and also validate in the model's save as a final check that we're not saving possibly bad benefit records to the database.
