### PR TITLE
Lightning talks categories are set to "Testing" - no option to select a category

### DIFF
--- a/pycon/forms.py
+++ b/pycon/forms.py
@@ -60,9 +60,6 @@ class PyConLightningTalkProposalForm(PyConProposalForm):
 
     def __init__(self, *args, **kwargs):
         super(PyConLightningTalkProposalForm, self).__init__(*args, **kwargs)
-        # TODO: This is a hack to populate the field...
-        self.fields['category'].widget = forms.HiddenInput()
-        self.fields['category'].initial = PyConProposalCategory.objects.all()[0]
         self.fields['audience_level'].widget = forms.HiddenInput()
         self.fields['audience_level'].initial = PyConLightningTalkProposal.AUDIENCE_LEVEL_NOVICE
 

--- a/symposion/templates/proposals/_proposal_fields.html
+++ b/symposion/templates/proposals/_proposal_fields.html
@@ -9,10 +9,10 @@
         <dd>{{ proposal.get_tags_display }}&nbsp;</dd>
     {% endif %}
 
-    {% if proposal.kind.slug != "lightning-talk" %}
-        <dt>{% trans "Category" %}</dt>
-        <dd>{{ proposal.category }}&nbsp;</dd>
+    <dt>{% trans "Category" %}</dt>
+    <dd>{{ proposal.category }}&nbsp;</dd>
 
+    {% if proposal.kind.slug != "lightning-talk" %}
         <dt>{% trans "Python Level" %}</dt>
         <dd>{{ proposal.get_audience_level_display }}&nbsp;</dd>
     {% endif %}


### PR DESCRIPTION
When someone proposes a lightning talk, the category is automatically set to "Testing" (viewed from the admin dashboard side).  It is also not available to select a category as a submitter.  Can we make it available for a submitter to choose? 
