### PR TITLE
Require travel plans on financial aid form

### DIFF
--- a/pycon/finaid/forms.py
+++ b/pycon/finaid/forms.py
@@ -1,5 +1,7 @@
 from django import forms
+from django.core.exceptions import ValidationError
 from django.forms import Textarea
+from django.utils.translation import ugettext_lazy as _
 
 from .models import FinancialAidApplication, FinancialAidMessage, \
     FinancialAidReviewData, FinancialAidEmailTemplate
@@ -47,6 +49,12 @@ class FinancialAidApplicationForm(forms.ModelForm):
                        'class': 'fullwidth-textarea',
                        'maxlength': 200}),
         }
+
+    def clean(self):
+        data = super(FinancialAidApplicationForm, self).clean()
+        if data['travel_grant_requested'] and not data['travel_plans']:
+            raise ValidationError(_(u"Travel plans are required if requesting a travel grant."))
+        return data
 
 
 class FinancialAidReviewForm(forms.ModelForm):

--- a/pycon/static/less/site.less
+++ b/pycon/static/less/site.less
@@ -314,9 +314,13 @@ header.main {
   width: 1px;
 }
 
-.required-field:before{
+.is_required {
   content: '*';
   color: @danger;
+}
+
+.required-field:before{
+  .is_required;
 }
 
 aside.list {
@@ -1546,5 +1550,14 @@ table.calendar {
       font-weight: normal;
       display:block;
     }
+  }
+}
+
+//Financial aid application form
+body.finaid {
+  // Mark travel plans as required even though technically they aren't
+  // required by the form.
+  label[for=id_travel_plans]:before {
+    .is_required;
   }
 }


### PR DESCRIPTION
More specifically, require travel plans on the financial aid form if and only
if a travel grant is requested. Implemented by leaving the form field
technically not required, adding form validation that looks at whether a
travel grant is requested, and marking the travel plans field with 'required'
styling manually.
