### PR TITLE
Cancelled proposal not shown in Dashboard

### DIFF
--- a/symposion/reviews/views.py
+++ b/symposion/reviews/views.py
@@ -351,6 +351,7 @@ def review_status(request, section_slug=None, key=None):
     queryset = ProposalBase.objects.select_related("speaker__user", "result").select_subclasses()
     if section_slug:
         queryset = queryset.filter(kind__section__slug=section_slug)
+    queryset = queryset.exclude(cancelled=True)
 
     proposals = {
         # proposals with at least VOTE_THRESHOLD reviews and at least one +1 and no -1s, sorted by the 'score'

--- a/symposion/templates/reviews/review_detail.html
+++ b/symposion/templates/reviews/review_detail.html
@@ -34,7 +34,9 @@
             <form class="result-form form-inline" method="POST" action="">
                 {% csrf_token %}
                 <div class="btn-group">
-                    {% if proposal.result.status == "accepted" %}
+                    {% if proposal.cancelled %}
+                        <div class="btn btn-danger">Cancelled</div>
+                    {% elif proposal.result.status == "accepted" %}
                         <a class="btn dropdown-toggle btn-success" data-toggle="dropdown" href="#">Accepted <span class="caret"></span></a>
                         <div class="dropdown-menu pull-right" style="width: 200px; padding-left: 10px;">
                             <div class="btn-group">


### PR DESCRIPTION
I can see [here](http://us.pycon.org/2014/admin/pycon/pyconlightningtalkproposal/) (admin site for pycon lightning talk proposals) that one user cancelled his proposal (it was just a test submission).  However, on the dashboard portion of the pycon site, I still see it [here](http://us.pycon.org/2014/reviews/review/30/#proposal-detail) and can not tell that it was cancelled.  I expect it to either disappear, or to have some tag/note on it saying it was cancelled/recalled by the user.  Not sure if this only happens on lightning talks or in general.

Thanks!  LR
