### PR TITLE
Easier team permission admin

### DIFF
--- a/symposion/teams/admin.py
+++ b/symposion/teams/admin.py
@@ -8,6 +8,7 @@ admin.site.register(
     Team,
     list_display=['name', 'access'],
     prepopulated_fields={"slug": ("name",)},
+    filter_horizontal=['permissions', 'manager_permissions'],
 )
 
 


### PR DESCRIPTION
Use horizontal filters in the admin for adjusting team permissions. The
permission list is long and trying to multi-select in a small list box is
painful.
