### PR TITLE
Fixes form submission error

### DIFF
--- a/pycon/finaid/forms.py
+++ b/pycon/finaid/forms.py
@@ -50,6 +50,10 @@ class FinancialAidApplicationForm(forms.ModelForm):
                        'maxlength': 200}),
         }
 
+    def __init__(self, *args, **kwargs):
+      super(FinancialAidApplicationForm, self).__init__(*args, **kwargs)
+      self.fields['sex'].required = False
+
     def clean(self):
         data = super(FinancialAidApplicationForm, self).clean()
         if data['travel_grant_requested'] and not data['travel_plans']:

--- a/pycon/finaid/models.py
+++ b/pycon/finaid/models.py
@@ -77,7 +77,6 @@ class FinancialAidApplication(models.Model):
         help_text=_("(Your sex will be used only to help assign roommates "
                     "for those requesting hotel assistance)"),
         default=SEX_NO_ANSWER,
-        blank=True,  # So the form won't show this field as required
     )
 
     travel_grant_requested = models.BooleanField(


### PR DESCRIPTION
Fixes #211 

Reproduced bug by submitting an App with `pyladies_grant_requested` set to True and `sex` set to the empty label value.
- Manually set field to `required = False`
- tidies up empty label vs default SEX_CHOICE options
