### PR TITLE
'terms and condition' link isn't working on the sponsorship -> apply page

### DIFF
--- a/pycon/templates/sponsorship/apply.html
+++ b/pycon/templates/sponsorship/apply.html
@@ -20,7 +20,7 @@
             <input class="btn btn-success" type="submit" value="{% trans "Apply" %}" />
             <p class="help-block">
               {% url 'cms_page' "sponsor/terms/" as terms_url %}
-                <em>{% blocktrans %}By submitting this sponsor application you are agreeing to the <a href="{{ termsurl }}" target="_blank">terms and conditions</a>.{% endblocktrans %}</em>
+                <em>{% blocktrans %}By submitting this sponsor application you are agreeing to the <a href="{{ terms_url }}" target="_blank">terms and conditions</a>.{% endblocktrans %}</em>
             </p>
         </div>
     </form>


### PR DESCRIPTION
http://us.pycon.org/2014/sponsors/apply/

Missing underscore in 'termsurl' perhaps?

https://github.com/caktus/pycon/blob/develop/pycon/templates/sponsorship/apply.html
