### PR TITLE
Add markdown rendering to speaker feedback

### DIFF
--- a/pycon/templatetags/pycon_markup.py
+++ b/pycon/templatetags/pycon_markup.py
@@ -1,0 +1,19 @@
+import markdown as mdown
+
+from django import template
+from django.template.defaultfilters import stringfilter
+from django.utils.encoding import force_unicode
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+@register.filter(is_safe=True)
+@stringfilter
+def markdown(value):
+    extensions = []  # ["nl2br", ]
+
+    return mark_safe(mdown.markdown(
+        force_unicode(value),
+        extensions,
+        safe_mode=True,
+        enable_attributes=False))

--- a/symposion/templates/reviews/review_detail.html
+++ b/symposion/templates/reviews/review_detail.html
@@ -4,6 +4,7 @@
 
 {% load bootstrap_tags %}
 {% load account_tags %}
+{% load pycon_markup %}
 
 {% block head_title %}#{{ proposal.number }} - {{ proposal.title }}{% endblock %}
 
@@ -188,7 +189,7 @@
                             <div class="commment-content">
                                 <b>{% user_display message.user %}</b>
                                 {{ message.submitted_at|timesince }} ago <br />
-                                {{ message.message|safe }}
+                                {{ message.message|markdown }}
                             </div>
                         </div>
                     {% endfor %}


### PR DESCRIPTION
It seems that most of the markdown that is working is using
client side rendering - not sure if there is a conflict with that
and the tabbed view - but this does "fix" the immediate problem.
