### PR TITLE
Move link for downloading financial aid data

### DIFF
--- a/pycon/finaid/context_processors.py
+++ b/pycon/finaid/context_processors.py
@@ -8,6 +8,7 @@ def financial_aid(request):
         "show_finaid_edit_button": open and has_application(request.user),
         "show_finaid_status_button": has_application(request.user),
         "show_finaid_review_button": is_reviewer(request.user),
+        "show_finaid_download_button": is_reviewer(request.user),
     }
 
     ctx["show_financial_aid_section"] = \

--- a/pycon/finaid/tests/test_views.py
+++ b/pycon/finaid/tests/test_views.py
@@ -377,6 +377,24 @@ class TestCSVExport(TestCase, TestMixin, ReviewTestMixin):
         rsp = self.client.post(self.url)
         self.assertRedirects(rsp, expected_url)
 
+    def test_reviewers_only(self):
+        # Only reviewers can download the data
+        self.make_not_reviewer(self.user)
+        self.login()
+        rsp = self.client.get(self.url)
+        self.assertEqual(403, rsp.status_code)
+        # and non-reviewers don't see the download link on their dashboard
+        rsp = self.client.get(reverse('dashboard'))
+        self.assertEqual(200, rsp.status_code)
+        self.assertNotIn(self.url, rsp.content)
+
+    def test_link_on_dashboard(self):
+        # Reviewers get a link on their dashboard
+        self.login()
+        rsp = self.client.get(reverse('dashboard'))
+        self.assertEqual(200, rsp.status_code)
+        self.assertIn(self.url, rsp.content, msg=rsp.content)
+
     def test_empty_data(self):
         # No data, should be able to get a CSV response anyway
         self.login()

--- a/pycon/finaid/views.py
+++ b/pycon/finaid/views.py
@@ -350,6 +350,9 @@ def finaid_status(request):
 def finaid_download_csv(request):
     # Download financial aid application data as a .CSV file
 
+    if not is_reviewer(request.user):
+        return HttpResponseForbidden(_(u"Not authorized for this page"))
+
     # Fields to include
     application_field_names = [
         name for name in FinancialAidApplication._meta.get_all_field_names()

--- a/pycon/templates/dashboard.html
+++ b/pycon/templates/dashboard.html
@@ -193,6 +193,12 @@
                             <span class="widget-label">Review applications</span>
                           </a>
                         {% endif %}
+                        {% if show_finaid_download_button %}
+                          <a href="{% url 'finaid_download_csv' %}" class="action">
+                            <i class="widget-icon icon-arrow-down"></i>
+                            <span class="widget-label">Download applications</span>
+                          </a>
+                        {% endif %}
                       </div>
                     </div>
                   </div>

--- a/pycon/templates/finaid/application_list.html
+++ b/pycon/templates/finaid/application_list.html
@@ -11,7 +11,6 @@
   <p>
     Use Search to filter by applicant or status.
     Click column headers to sort.
-    <a href="{% url 'finaid_download_csv' %}">Download data.</a>
   </p>
 
   <form action="" method="POST" accept-charset="utf-8" id="applicant-list">


### PR DESCRIPTION
Per Diana:

Can we please move the download data link to the dashboard, in a square box
under the "Financial Aid" section. Like how the "Download sponsor logos"
was done.

https://staging-pycon.python.org/2014/dashboard/ 
