### PR TITLE
Fixed #256, ensures abstract converts markdown

### DIFF
--- a/pycon/templates/schedule/presentation_detail.html
+++ b/pycon/templates/schedule/presentation_detail.html
@@ -14,6 +14,8 @@
             $('.tutorial-comment').each(function() {
                 $(this).html(converter.makeHtml($(this).html()));
             })
+            $('.abstract').html(converter.makeHtml($('.abstract').html()));
+
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
Configure Markdown converter to process **abstract** field on presentation detail page.
