### PR TITLE
alerts moved under header, no longer overlaying content.

### DIFF
--- a/pycon/templates/_messages.html
+++ b/pycon/templates/_messages.html
@@ -1,6 +1,14 @@
-{% for message in messages %}
-    <div class="top alert fade in {% if message.tags %} alert-{{ message.tags }}{% endif %}">
-        <button type="button" class="close" data-dismiss="alert">&times;</button>
-        {{ message }}
+{% if messages %}
+    <div class="container">
+        <div class="row">
+            <div class="span12">
+            {% for message in messages %}
+                <div class="alert fade in {% if message.tags %} alert-{{ message.tags }}{% endif %}">
+                    <button type="button" class="close" data-dismiss="alert">&times;</button>
+                    {{ message }}
+                </div>
+            {% endfor %}
+            </div>
+        </div>
     </div>
-{% endfor %}
+{% endif %}

--- a/pycon/templates/site_base.html
+++ b/pycon/templates/site_base.html
@@ -49,7 +49,6 @@
 {% endblock %}
 
 {% block topbar_base %}
-    {% include "_messages.html" %}
     <header class="main">
         <a id="skip" href="#content">{% trans "Skip to main content" %}</a>
         <div class="container">
@@ -90,6 +89,7 @@
                 </div>
             </div>
             <div class="page-content">
+                {% include "_messages.html" %}
                 {% block page_content %}
                 <div class="container">
 


### PR DESCRIPTION
Relates to a UI problem pointed out in https://github.com/PyCon/2014/issues/72 by dianeclarke.

Before:
![before](https://cloud.githubusercontent.com/assets/470417/2822054/4686505c-cf0e-11e3-9ffe-c42dbcd50825.png)
After:
![after](https://cloud.githubusercontent.com/assets/470417/2822056/4bfe24b0-cf0e-11e3-97a8-e8150f90fb2a.png)

I adjusted the messages to be in their own container as needed-- otherwise it'd have to live in the container div underneath, which could be overwritten by a child template by mistake and hide the alerts.
