### PR TITLE
Removing registration link until reg is open (or close to)

### DIFF
--- a/pycon/templates/homepage.html
+++ b/pycon/templates/homepage.html
@@ -28,17 +28,6 @@
                             <li class="box-shadow"><strong>{% trans "Tutorials" %}</strong> April 8&ndash;9</li>
                             <li class="box-shadow"><strong>{% trans "Conference" %}</strong> April 10&ndash;12</li>
                             <li class="box-shadow"><strong>{% trans "Sprints" %}</strong> April 13&ndash;16</li>
-                            {% if config.REGISTRATION_STATUS != 'open' %}
-                            <li class="box-shadow promo no-link">
-                                {% if config.REGISTRATION_STATUS == 'soon' %}
-                                    <p>{% trans "Register Fall 2014" %}</p>
-                                {% elif config.REGISTRATION_STATUS == 'closed' %}
-                                    <p class="small">{% trans "Registration Closed" %}</p>
-                                {% else %}
-                                    <p>&nbsp;&nbsp;</p>
-                                {% endif %}
-                            </li>
-                            {% endif %}
                             <div class="details">
                                 <span itemprop="locality">Montreal</span>,
                                 <span itemprop="country-name">Canada</span>,


### PR DESCRIPTION
I'm questioning the value of a disabled registration button with "Fall 2014" label that provides no value or confuses the user. As we get close to opening registration with concrete date, that's a different story. For now, anyway, I've removed the code snippet.
