### PR TITLE
Change wording on the team_detail status page.

### DIFF
--- a/pycon/templates/teams/team_detail.html
+++ b/pycon/templates/teams/team_detail.html
@@ -15,7 +15,7 @@
             <div class="span12">
                 {% if state %}
                     <h1>
-                        {% blocktrans with name=team.name %}You are a <em>{{ state }}</em> of {{ name }}{% endblocktrans %}
+                        {% blocktrans with name=team.name %}Your status is <em>{{ state }}</em> for {{ name }}.{% endblocktrans %}
                     </h1>
                 {% endif %}
 


### PR DESCRIPTION
This is a small change to the wording for a user's status when they join or are rejected from a team. The current wording says "You are a applied for Talk Reviewers" and, after the pull request, it will say "Your status is applied for Talk Reviewers." It's not perfect but I think it's an improvement. The tough thing is that statuses have different grammatical tenses in a sense so it's hard to find a perfect fit for all of them.
