### PR TITLE
Fix for issue #350 - image being rendered over a link, rendering it unclickable

### DIFF
--- a/pycon/static/less/site.less
+++ b/pycon/static/less/site.less
@@ -390,6 +390,7 @@ aside {
         -moz-transform: translate(-50%,0);
         -ms-transform: translate(-50%,0);
         margin-left: 50.5%;
+        z-index: -1;
       }
   }
 }


### PR DESCRIPTION
I sent it to the back using z-index which seems to have done the trick. Tested in OSX Chrome & Firefox.

(also figured out how to git better)
