### PR TITLE
Quick hack to show cancelled status to non_staff

### DIFF
--- a/symposion/templates/reviews/review_detail.html
+++ b/symposion/templates/reviews/review_detail.html
@@ -31,57 +31,63 @@
 
 
 {% block body %}
-    {% if request.user.is_staff %}
+    {% if proposal.cancelled %}
         <div class="pull-right">
-            <form class="result-form form-inline" method="POST" action="">
-                {% csrf_token %}
-                <div class="btn-group">
-                    {% if proposal.cancelled %}
-                        <div class="btn btn-danger">Cancelled</div>
-                    {% elif proposal.result.status == "accepted" %}
-                        <a class="btn dropdown-toggle btn-success" data-toggle="dropdown" href="#">Accepted <span class="caret"></span></a>
-                        <div class="dropdown-menu pull-right" style="width: 200px; padding-left: 10px;">
-                            <div class="btn-group">
-                                <input type="submit" name="result_submit" value="reject" class="btn btn-mini btn-danger" />
-                                <input type="submit" name="result_submit" value="standby" class="btn btn-mini" />
-                                <input type="submit" name="result_submit" value="undecide" class="btn btn-mini" />
-                            </div>
-                        </div>
-                    {% else %}
-                        {% if proposal.result.status == "rejected" %}
-                            <a class="btn dropdown-toggle btn-danger" data-toggle="dropdown" href="#">Rejected <span class="caret"></span></a>
+            <div class="btn-group">
+                <div class="btn btn-danger">Cancelled</div>
+            </div>
+        </div>
+    {% else %}
+        {% if request.user.is_staff %}
+            <div class="pull-right">
+                <form class="result-form form-inline" method="POST" action="">
+                    {% csrf_token %}
+                    <div class="btn-group">
+                        {% if proposal.result.status == "accepted" %}
+                            <a class="btn dropdown-toggle btn-success" data-toggle="dropdown" href="#">Accepted <span class="caret"></span></a>
                             <div class="dropdown-menu pull-right" style="width: 200px; padding-left: 10px;">
                                 <div class="btn-group">
-                                    <input type="submit" name="result_submit" value="accept" class="btn btn-mini btn-success" />
+                                    <input type="submit" name="result_submit" value="reject" class="btn btn-mini btn-danger" />
                                     <input type="submit" name="result_submit" value="standby" class="btn btn-mini" />
                                     <input type="submit" name="result_submit" value="undecide" class="btn btn-mini" />
                                 </div>
                             </div>
                         {% else %}
-                            {% if proposal.result.status == "standby" %}
-                                <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">Standby <span class="caret"></span></a>
+                            {% if proposal.result.status == "rejected" %}
+                                <a class="btn dropdown-toggle btn-danger" data-toggle="dropdown" href="#">Rejected <span class="caret"></span></a>
                                 <div class="dropdown-menu pull-right" style="width: 200px; padding-left: 10px;">
                                     <div class="btn-group">
                                         <input type="submit" name="result_submit" value="accept" class="btn btn-mini btn-success" />
-                                        <input type="submit" name="result_submit" value="reject" class="btn btn-mini btn-danger" />
+                                        <input type="submit" name="result_submit" value="standby" class="btn btn-mini" />
                                         <input type="submit" name="result_submit" value="undecide" class="btn btn-mini" />
                                     </div>
                                 </div>
                             {% else %}
-                                <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">Undecided <span class="caret"></span></a>
-                                <div class="dropdown-menu pull-right" style="width: 200px; padding-left: 10px;">
-                                    <div class="btn-group">
-                                        <input type="submit" name="result_submit" value="accept" class="btn btn-mini btn-success" />
-                                        <input type="submit" name="result_submit" value="reject" class="btn btn-mini btn-danger" />
-                                        <input type="submit" name="result_submit" value="standby" class="btn btn-mini" />
+                                {% if proposal.result.status == "standby" %}
+                                    <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">Standby <span class="caret"></span></a>
+                                    <div class="dropdown-menu pull-right" style="width: 200px; padding-left: 10px;">
+                                        <div class="btn-group">
+                                            <input type="submit" name="result_submit" value="accept" class="btn btn-mini btn-success" />
+                                            <input type="submit" name="result_submit" value="reject" class="btn btn-mini btn-danger" />
+                                            <input type="submit" name="result_submit" value="undecide" class="btn btn-mini" />
+                                        </div>
                                     </div>
-                                </div>
+                                {% else %}
+                                    <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">Undecided <span class="caret"></span></a>
+                                    <div class="dropdown-menu pull-right" style="width: 200px; padding-left: 10px;">
+                                        <div class="btn-group">
+                                            <input type="submit" name="result_submit" value="accept" class="btn btn-mini btn-success" />
+                                            <input type="submit" name="result_submit" value="reject" class="btn btn-mini btn-danger" />
+                                            <input type="submit" name="result_submit" value="standby" class="btn btn-mini" />
+                                        </div>
+                                    </div>
+                                {% endif %}
                             {% endif %}
                         {% endif %}
-                    {% endif %}
-                </div>
-            </form>
-        </div>
+                    </div>
+                </form>
+            </div>
+        {% endif %}
     {% endif %}
 
     <h3>#{{ proposal.number }}: {{ proposal.title }} ({{ proposal.speaker }}, Category: {{ proposal.category }})</h3>


### PR DESCRIPTION
The diff is not as extreme as it looks, I just moved out the "cancelled" div from the `{% if request.user.is_staff %}`

I didn't have a lot of time and without the staging database was struggling to get up and running with all the groups for review etc. If I had a proper db, I'd write a test and do this properly. 

But in the meantime, I thought I'd share this quick hack.

I don't expect you to merge this. But maybe it'll help someone do it properly.
