### PR TITLE
display the review and voting start dates in review lists

### DIFF
--- a/symposion/reviews/views.py
+++ b/symposion/reviews/views.py
@@ -111,6 +111,7 @@ def review_section(request, section_slug, assigned=False):
     ctx = {
         "proposals": proposals,
         "section": section,
+        "section_slug": section_slug,
         "can_manage": can_manage,
         "status_options": PyConProposal.STATUS_OPTIONS
     }
@@ -138,6 +139,7 @@ def review_list(request, section_slug, user_pk):
 
     ctx = {
         "proposals": proposals,
+        "section_slug": section_slug,
     }
     return render(request, "reviews/review_list.html", ctx)
 

--- a/symposion/templates/reviews/_review_table.html
+++ b/symposion/templates/reviews/_review_table.html
@@ -8,9 +8,13 @@
         <th>{% trans "Title" %}</th>
         <th>{% trans "Category" %}</th>
         <th>{% trans "Tags" %}</th>
-        <th>{% trans "Review Start" %}</th>
+        {% if section_slug == "talks" %}
+            <th>{% trans "Review Start" %}</th>
+        {% endif %}
         <th><i class="icon-comment-alt"></i></th>
-        <th>{% trans "Voting Start" %}</th>
+        {% if section_slug == "talks" %}
+            <th>{% trans "Voting Start" %}</th>
+        {% endif %}
         <th>+1</th>
         <th>+0</th>
         <th>-0</th>
@@ -40,9 +44,13 @@
                 <td>{{ proposal.title }}</td>
                 <td>{{ proposal.category }}</td>
                 <td>{{ proposal.get_tags_display }}</td>
-                <td>{{ proposal.result.group.review_start|date:"M. j H:i T" }}</td>
+                {% if section_slug == "talks" %}
+                    <td>{{ proposal.result.group.review_start|date:"M. j H:i T" }}</td>
+                {% endif %}
                 <td>{{ proposal.comment_count }}</td>
-                <td>{{ proposal.result.group.vote_start|date:"M. j H:i T" }}</td>
+                {% if section_slug == "talks" %}
+                    <td>{{ proposal.result.group.vote_start|date:"M. j H:i T" }}</td>
+                {% endif %}
                 <td>{{ proposal.plus_one }}</td>
                 <td>{{ proposal.plus_zero }}</td>
                 <td>{{ proposal.minus_zero }}</td>


### PR DESCRIPTION
It'd be great to see the start dates in review lists.

Being able to sort them is especially helpful for reviewers, so they can see which of their assigned talks are up for review/voting at present.
