### PR TITLE
Fix header img margin quirk

### DIFF
--- a/pycon/static/less/site.less
+++ b/pycon/static/less/site.less
@@ -387,10 +387,6 @@ aside {
         position: relative;
         top: -130px;
         max-width: 940px;
-        -webkit-transform: translate(-50%,0);
-        -moz-transform: translate(-50%,0);
-        -ms-transform: translate(-50%,0);
-        margin-left: 50.5%;
         z-index: -1;
       }
   }


### PR DESCRIPTION
refs #368 

This is a workaround (super duper hack) to fix the issue in #368 