### PR TITLE
Add some config to do development in a vagrant server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ program_export/
 .coverage
 htmlcov/
 env/
+.vagrant

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,7 @@ TEST_COMMAND = $(VIRTUAL_ENV)/bin/django-admin.py
 
 DJANGO_SETTINGS_MODULE = pycon.settings.test
 
-all:
-	make test
-	make flake8
+all: flake8 test
 
 test:
 	$(TEST_COMMAND) test --noinput --settings=$(DJANGO_SETTINGS_MODULE)

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,24 @@ at https://readthedocs.org/projects/pycon/.
 To get running locally
 ----------------------
 
+* First, if you're not on Ubuntu 12.04, you might need to do the following in
+  a virtual machine that is running Ubuntu 12.04.  You can use the provided
+  Vagrantfile to create one and install some of the prerequisites::
+
+    $ vagrant up
+
+  That'll have the current local directory mounted internally as /vagrant, but
+  it's not a full-featured file system so tox won't work right. What I did was
+  copy the files to the user's home directory::
+
+    $ vagrant ssh
+    [now in vagrant system, logged in as vagrant, with sudo privs]
+    $ cd /vagrant
+    $ rsync -avz * ~
+    $ cd ~
+
+  and then continue working there with the following instructions.
+
 * Create a new virtualenv and activate it::
 
     $ virtualenv env/pycon
@@ -19,7 +37,7 @@ To get running locally
 
 * Install the requirements for running and testing locally::
 
-    $ pip install -r requirements/dev.txt
+    $ pip install --trusted-host dist.pinaxproject.com -r requirements/dev.txt
 
   (For production, install -r requirements/project.txt).
 
@@ -42,9 +60,23 @@ To get running locally
 
   Change ``pycon2015`` in that first command to the name of your local database.
 
+* Otherwise, create a new empty database::
+
+    $ createdb pycon2015
+    $ ./manage.py syncdb
+
 * Run local server::
 
     python manage.py runserver
+
+* Run tests::
+
+    $ tox
+
+ or
+
+    $ make test
+
 
 For production
 --------------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,75 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "hashicorp/precise64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network "forwarded_port", guest: 80, host: 8000
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline <<-SHELL
+  #   sudo apt-get install apache2
+  # SHELL
+
+  config.vm.provision :shell, path: "vagrant_bootstrap.sh"
+
+end

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
               'symposion.sponsorship', 'symposion.sponsorship.templatetags'],
     url='https://github.com/caktus/pycon/',
     license='LICENSE',
-    author='',
-    author_email='',
+    maintainer='Caktus Consulting Group',
+    maintainer_email='pycon@caktusgroup.com',
     description=''
 )

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,7 @@ deps = -r{toxinidir}/requirements/test.txt
 basepython = python2.7
 setenv = PYTHON_PATH = {toxinidir}
     DJANGO_SETTINGS_MODULE = pycon.settings.test
-#commands = {envpython} manage.py test {posargs}
-commands = make -k
+commands = {envpython} manage.py test {posargs}
 install_command=pip install --trusted-host dist.pinaxproject.com {opts} {packages}
 
 [testenv:pycon]

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ deps = -r{toxinidir}/requirements/test.txt
 basepython = python2.7
 setenv = PYTHON_PATH = {toxinidir}
     DJANGO_SETTINGS_MODULE = pycon.settings.test
-commands = {envpython} manage.py test {posargs}
+#commands = {envpython} manage.py test {posargs}
+commands = make -k
 install_command=pip install --trusted-host dist.pinaxproject.com {opts} {packages}
 
 [testenv:pycon]

--- a/vagrant_bootstrap.sh
+++ b/vagrant_bootstrap.sh
@@ -7,4 +7,17 @@ hash -r
 pip install -U pip
 hash -r
 pip install virtualenv virtualenvwrapper
-sudo -u postgres createuser --superuser vagrant
+sudo -u postgres createuser --superuser vagrant || true
+
+# We want nodejs 0.10.11 to match our Chef servers
+if [ ! -e /usr/local/bin/npm ] ; then
+  wget https://nodejs.org/dist/v0.10.11/node-v0.10.11-linux-x64.tar.gz
+  tar xzf node-v0.10.11-linux-x64.tar.gz
+  (tar cf - -C node-v0.10.11-linux-x64) | (tar xf - -C /usr/local)
+fi
+
+# And postgres 9.3
+# TODO!
+
+# Now we can install less
+npm install -g less@1.3.3

--- a/vagrant_bootstrap.sh
+++ b/vagrant_bootstrap.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+apt-get update -qqy
+apt-get purge python-pip -y
+apt-get install python-pip git-core postgresql-9.1 postgresql-client-9.1 postgresql-server-dev-9.1 libpq5 libpq-dev python-dev -y
+hash -r
+pip install -U pip
+hash -r
+pip install virtualenv virtualenvwrapper
+sudo -u postgres createuser --superuser vagrant

--- a/vagrant_bootstrap.sh
+++ b/vagrant_bootstrap.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 set -e
+
+# Add Postgresql apt repo
+wget -O - http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | apt-key add -
+echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+
 apt-get update -qqy
 apt-get purge python-pip -y
-apt-get install python-pip git-core postgresql-9.1 postgresql-client-9.1 postgresql-server-dev-9.1 libpq5 libpq-dev python-dev make -y
+apt-get install python-pip git-core postgresql-9.3 postgresql-client-9.3 postgresql-server-dev-9.3 libpq-dev python-dev make  -y
 hash -r
 pip install -U pip
 hash -r
@@ -13,11 +18,10 @@ sudo -u postgres createuser --superuser vagrant || true
 if [ ! -e /usr/local/bin/npm ] ; then
   wget https://nodejs.org/dist/v0.10.11/node-v0.10.11-linux-x64.tar.gz
   tar xzf node-v0.10.11-linux-x64.tar.gz
-  (tar cf - -C node-v0.10.11-linux-x64) | (tar xf - -C /usr/local)
+  (tar cf - -C node-v0.10.11-linux-x64 .) | (tar xf - -C /usr/local)
 fi
-
-# And postgres 9.3
-# TODO!
 
 # Now we can install less
 npm install -g less@1.3.3
+
+sudo -u vagrant rsync -az /vagrant/* ~vagrant

--- a/vagrant_bootstrap.sh
+++ b/vagrant_bootstrap.sh
@@ -2,7 +2,7 @@
 set -e
 apt-get update -qqy
 apt-get purge python-pip -y
-apt-get install python-pip git-core postgresql-9.1 postgresql-client-9.1 postgresql-server-dev-9.1 libpq5 libpq-dev python-dev -y
+apt-get install python-pip git-core postgresql-9.1 postgresql-client-9.1 postgresql-server-dev-9.1 libpq5 libpq-dev python-dev make -y
 hash -r
 pip install -U pip
 hash -r


### PR DESCRIPTION
If your local dev system is newer than Ubuntu 12.04, the
current code won't work (wrong versions of libraries etc.
to build the required python package versions), so this
lets you run a vagrant system that is running Ubuntu
12.04.

There's a little doc added to the README.rst.