### PR TITLE
Upgrade Pillow to 2.9.0

### DIFF
--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -6,7 +6,7 @@
 # Put project-specific requirements here.
 # See http://pip-installer.org/requirement-format.html for more information.
 
-Pillow==2.0.0
+Pillow==2.9.0
 easy-thumbnails==1.2
 html5lib==0.999
 django-social-auth==0.7.23


### PR DESCRIPTION
Pillow 2.0.0 won't build on Ubuntu 14.04.
Pillow 2.9.0 builds on both Ubuntu 12.04 and 14.04, so upgrading
will make it easier to do development.