### PR TITLE
Minor fixups for salt deployment

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -17,33 +17,27 @@ env.settings = 'symposion.settings'
 @task
 def staging():
     env.environment = 'staging'
-    env.hosts = ['virt-nsz0jn.psf.osuosl.org']
+    env.hosts = ['pycon-staging.iad1.psf.io']
     env.site_hostname = 'staging-pycon.python.org'
-    env.root = '/srv/staging-pycon.python.org'
+    env.root = '/srv/pycon'
     env.branch = 'staging'
-    env.db = 'psf-pycon-2016-staging'
-    env.db_host = 'pg2.osuosl.org'
-    env.db_user = 'psf-pycon-2016-staging'
     setup_path()
 
 @task
 def production():
     env.environment = 'production'
-    env.hosts = ['virt-ak9lsk.psf.osuosl.org']
+    env.hosts = ['pycon-prod.iad1.psf.io']
     env.site_hostname = 'us.pycon.org'
-    env.root = '/srv/staging-pycon.python.org'
+    env.root = '/srv/pycon'
     env.branch = 'production'
-    env.db = 'psf-pycon-2016'
-    env.db_host = 'pg2.osuosl.org'
-    env.db_user = 'psf-pycon-2016'
     setup_path()
 
 
 def setup_path():
     env.home = '/home/%(project_user)s/' % env
-    env.code_root = os.path.join(env.root, 'current')
-    env.virtualenv_root = os.path.join(env.root, 'shared/env')
-    env.media_root = os.path.join(env.root, 'shared', 'media')
+    env.code_root = os.path.join(env.root, 'pycon')
+    env.virtualenv_root = os.path.join(env.root, 'env')
+    env.media_root = os.path.join(env.root, 'media')
 
 
 @task
@@ -53,9 +47,8 @@ def manage_run(command):
     manage_cmd = ("{env.virtualenv_root}/bin/python "
         "manage.py {command}").format(env=env, command=command)
     dotenv_path = os.path.join(env.root, 'shared')
-    source_dotenv_cmd = ". {env}/.env".format(env=dotenv_path)
     with cd(env.code_root):
-        sudo(' && '.join((source_dotenv_cmd, manage_cmd)))
+        sudo(manage_cmd)
 
 
 @task
@@ -71,7 +64,7 @@ def deploy():
     # repo has changed, and if so, redeploy.  Or you can use this
     # to make it run immediately.
     require('environment')
-    sudo('chef-client')
+    sudo('salt-call state.highstate')
 
 @task
 def ssh():

--- a/fabfile.py
+++ b/fabfile.py
@@ -61,7 +61,7 @@ def manage_shell():
 @task
 def deploy():
     """Deploy to a given environment."""
-    # NOTE: chef will check every 30 minutes or so whether the
+    # NOTE: salt will check every 15 minutes whether the
     # repo has changed, and if so, redeploy.  Or you can use this
     # to make it run immediately.
     require('environment')

--- a/fabfile.py
+++ b/fabfile.py
@@ -13,6 +13,7 @@ env.project = 'pycon'
 env.project_user = os.environ['LOGNAME']
 env.shell = '/bin/bash -c'
 env.settings = 'symposion.settings'
+env.use_ssh_config = True
 
 @task
 def staging():

--- a/pycon/management/commands/sqldsn.py
+++ b/pycon/management/commands/sqldsn.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+"""
+sqldns.py - Prints Data Source Name on stdout
+
+Copied, Trimmed, and Modified from django-extensions module
+
+Copyright (c) 2007 Michael Trier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import sys
+from optparse import make_option
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.core.management.color import color_style
+
+
+class Command(BaseCommand):
+    option_list = BaseCommand.option_list + (
+        make_option('-R', '--router', action='store',
+                    dest='router', default='default',
+                    help='Use this router-database other then default'),
+        make_option('-s', '--style', action='store',
+                    dest='style', default=None,
+                    help='DSN format style: keyvalue, uri, pgpass, all'),
+        make_option('-a', '--all', action='store_true',
+                    dest='all', default=False,
+                    help='Show DSN for all database routes'),
+        make_option('-q', '--quiet', action='store_true',
+                    dest='quiet', default=False,
+                    help='Quiet mode only show DSN'),
+    )
+    help = """Prints DSN on stdout, as specified in settings.py
+    ./manage.py sqldsn [--router=<routername>] [--style=pgpass]"""
+
+    requires_system_checks = False
+    can_import_settings = True
+
+    def handle(self, *args, **options):
+        self.style = color_style()
+        all_routers = options.get('all')
+
+        if all_routers:
+            routers = settings.DATABASES.keys()
+        else:
+            routers = [options.get('router')]
+
+        for i, router in enumerate(routers):
+            if i != 0:
+                sys.stdout.write("\n")
+            self.show_dsn(router, options)
+
+    def show_dsn(self, router, options):
+        dbinfo = settings.DATABASES.get(router)
+        quiet = options.get('quiet')
+        dsn_style = options.get('style')
+
+        if dbinfo is None:
+            raise CommandError("Unknown database router %s" % router)
+
+        engine = dbinfo.get('ENGINE').split('.')[-1]
+        dbuser = dbinfo.get('USER')
+        dbpass = dbinfo.get('PASSWORD')
+        dbname = dbinfo.get('NAME')
+        dbhost = dbinfo.get('HOST')
+        dbport = dbinfo.get('PORT')
+
+        dsn = []
+
+        if engine == 'postgresql_psycopg2':
+            dsn.append(self.postgresql(dbhost, dbport, dbname, dbuser, dbpass, options=dbinfo.get('OPTIONS'), dsn_style=dsn_style))
+
+        else:
+            dsn.append(self.style.ERROR('Unknown database, can''t generate DSN'))
+
+        if not quiet:
+            sys.stdout.write(self.style.SQL_TABLE("DSN for router '%s' with engine '%s':\n" % (router, engine)))
+
+        for output in dsn:
+            sys.stdout.write("{}\n".format(output))
+
+    def postgresql(self, dbhost, dbport, dbname, dbuser, dbpass, dsn_style=None, options=None):
+        if dsn_style is None:
+            dsnstr = "host='{0}' dbname='{2}' user='{3}'"
+
+            if dbport is not None:
+                dsnstr = dsnstr + " port='{1}'"
+
+            dsn = dsnstr.format(dbhost,
+                                dbport,
+                                dbname,
+                                dbuser,)
+
+            for k, v in options.iteritems():
+                dsn += " %s=%s" % (k, v)
+
+        elif dsn_style == 'pgpass':
+            if dbport is not None:
+                dbport = 5432
+            dsn = '{0}:{1}:{2}:{3}:{4}'.format(dbhost,
+                                               dbport,
+                                               dbname,
+                                               dbuser,
+                                               dbpass)
+        else:
+            raise ValueError('supplied dsn_style not supported')
+
+        return dsn

--- a/pycon/settings/server.py
+++ b/pycon/settings/server.py
@@ -9,11 +9,11 @@ from .base import *
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql_psycopg2",
-        "NAME": os.environ['DB_NAME'],
-        "USER": os.environ['DB_USER'],
-        "PASSWORD": os.environ['DB_PASSWORD'],
-        "HOST": os.environ['DB_HOST'],
-        "PORT": os.environ['DB_PORT'],
+        "NAME": env_or_default('DB_NAME', ''),
+        "USER": env_or_default('DB_USER', ''),
+        "PASSWORD": env_or_default('DB_PASSWORD', ''),
+        "HOST": env_or_default('DB_HOST', ''),
+        "PORT": env_or_default('DB_PORT', ''),
     }
 }
 
@@ -24,7 +24,7 @@ ALLOWED_HOSTS = [
     socket.getfqdn(),
 ]
 
-SECRET_KEY = os.environ['SECRET_KEY']
+SECRET_KEY = env_or_default('SECRET_KEY', '')
 
 ADMINS = (
     ('Ernest W. Durbin III', 'ewdurbin@gmail.com'),
@@ -45,7 +45,7 @@ SERVE_MEDIA = False
 # yes, use django-compressor on the server
 COMPRESS_ENABLED = True
 
-MEDIA_ROOT = os.environ['MEDIA_ROOT']
+MEDIA_ROOT = env_or_default('MEDIA_ROOT', '')
 
 from django.utils.log import DEFAULT_LOGGING
 LOGGING = DEFAULT_LOGGING.copy()
@@ -74,7 +74,7 @@ LOGGING['handlers'].update(
         },
         'sam_gelf': {
             'class': 'graypy.GELFHandler',
-            'host': os.environ['GRAYLOG_HOST'],
+            'host': env_or_default('GRAYLOG_HOST', ''),
             'port': 12201,
             'filters': ['static_fields', 'django_exc'],
         }

--- a/pycon/static/less/bootstrap/mixins.less
+++ b/pycon/static/less/bootstrap/mixins.less
@@ -558,13 +558,13 @@
   .core (@gridColumnWidth, @gridGutterWidth) {
 
     .spanX (@index) when (@index > 0) {
-      (~".span@{index}") { .span(@index); }
+      .span@{index} { .span(@index); }
       .spanX(@index - 1);
     }
     .spanX (0) {}
 
     .offsetX (@index) when (@index > 0) {
-      (~".offset@{index}") { .offset(@index); }
+      .offset@{index} { .offset(@index); }
       .offsetX(@index - 1);
     }
     .offsetX (0) {}
@@ -603,14 +603,14 @@
   .fluid (@fluidGridColumnWidth, @fluidGridGutterWidth) {
 
     .spanX (@index) when (@index > 0) {
-      (~".span@{index}") { .span(@index); }
+      .span@{index} { .span(@index); }
       .spanX(@index - 1);
     }
     .spanX (0) {}
 
     .offsetX (@index) when (@index > 0) {
-      (~'.offset@{index}') { .offset(@index); }
-      (~'.offset@{index}:first-child') { .offsetFirstChild(@index); }
+      .offset@{index} { .offset(@index); }
+      .offset@{index}:first-child { .offsetFirstChild(@index); }
       .offsetX(@index - 1);
     }
     .offsetX (0) {}
@@ -658,7 +658,7 @@
   .input(@gridColumnWidth, @gridGutterWidth) {
 
     .spanX (@index) when (@index > 0) {
-      (~"input.span@{index}, textarea.span@{index}, .uneditable-input.span@{index}") { .span(@index); }
+      input.span@{index}, textarea.span@{index}, .uneditable-input.span@{index} { .span(@index); }
       .spanX(@index - 1);
     }
     .spanX (0) {}


### PR DESCRIPTION
- Don't blow up on direct calls to `os.environ` in `setting.server`
  - The new salt deployment tooling relies less on environment variables, and leans heavily on tempting files onto the file system. This also does away with the `IS_PRODUCTION` environment variable, so there are other things we can tidy up as well
- Modify LESS for syntax changes
  - HONESTLY NO IDEA WHAT I'M DOING, just modified to get `manage.py compress` working.
- Fixes all fabric tasks to work with new infrastructure