### PR TITLE
Fixing some warnings

### DIFF
--- a/pycon/finaid/forms.py
+++ b/pycon/finaid/forms.py
@@ -47,6 +47,9 @@ class FinancialAidReviewForm(forms.ModelForm):
 
     class Meta:
         model = FinancialAidReviewData
+        fields = ['status', 'amount', 'grant_letter_sent', 'cash_check',
+                  'notes', 'travel_cash_check', 'disbursement_notes',
+                  'promo_code']
         widgets = {
             'notes': Textarea(
                 attrs={'cols': 80, 'rows': 5,

--- a/pycon/migrations/0003_auto_20150731_1306.py
+++ b/pycon/migrations/0003_auto_20150731_1306.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pycon', '0002_remove_old_google_openid_auths'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='pycontutorialproposal',
+            name='registrants',
+            field=models.ManyToManyField(help_text='CTE registered participants for this tutorial.', to=settings.AUTH_USER_MODEL, editable=False, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/pycon/models.py
+++ b/pycon/models.py
@@ -217,7 +217,7 @@ class PyConTutorialProposal(PyConProposal):
 
     # Populated by update_tutorial_registrant command.
     registrants = models.ManyToManyField(
-        settings.AUTH_USER_MODEL, blank=True, null=True, editable=False,
+        settings.AUTH_USER_MODEL, blank=True, editable=False,
         help_text=_(u'CTE registered participants for this tutorial.'))
     registration_count = models.IntegerField(
         default=0, editable=False,

--- a/pycon/profile/forms.py
+++ b/pycon/profile/forms.py
@@ -7,6 +7,7 @@ class ProfileForm(forms.ModelForm):
     
     class Meta:
         model = Profile
+        fields = ['first_name', 'last_name', 'phone']
     
     def __init__(self, *args, **kwargs):
         super(ProfileForm, self).__init__(*args, **kwargs)

--- a/pycon/settings/base.py
+++ b/pycon/settings/base.py
@@ -374,8 +374,13 @@ CACHES = {
 # Is somebody clobbering this?  We shouldn't have to set it ourselves,
 # but if we don't, gunicorn's django_wsgi blows up trying to configure
 # logging with an empty dictionary.
+import copy
 from django.utils.log import DEFAULT_LOGGING
-LOGGING = DEFAULT_LOGGING
+LOGGING = copy.deepcopy(DEFAULT_LOGGING)
+LOGGING.setdefault('root', {
+    # Default root logger, just so everything has a handler and we don't see warnings
+    'handlers': ['null'],  # null handler is defined in the default logging config
+})
 
 BLEACH_ALLOWED_TAGS = bleach.ALLOWED_TAGS + ['p']
 

--- a/pycon/sponsorship/managers.py
+++ b/pycon/sponsorship/managers.py
@@ -4,7 +4,7 @@ from django.db import models
 class SponsorManager(models.Manager):
 
     def active(self):
-        return self.get_query_set().filter(active=True).order_by("level")
+        return self.get_queryset().filter(active=True).order_by("level")
 
     def with_weblogo(self):
         queryset = self.raw("""

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,15 +20,15 @@ git+https://github.com/dpoirier/django-openid.git@minimal_django17#egg=django-op
 
 python-openid==2.2.5
 django_compressor==1.5
-git+git://github.com/caktus/biblion.git@feature/django-1.7#egg=biblion
--e git+git://github.com/daaray/django-sitetree.git#egg=django-sitetree
+git+git://github.com/caktus/biblion.git@feature/django-1.8#egg=biblion
+git+git://github.com/caktus/django-sitetree.git#egg=django-sitetree
 -e git+git://github.com/shvechikov/python-rtfng.git#egg=python-rtfng
 
 django-taggit==0.15.0
-django-reversion==1.7
+django-reversion==1.8.7
 django-markitup==1.0.0
 Markdown==2.3.1
-django-selectable==0.7.0
+django-selectable==0.9.0
 
 django-forms-bootstrap==2.0.3.post1
 django-uni-form==0.9.0

--- a/requirements/project.txt
+++ b/requirements/project.txt
@@ -18,9 +18,9 @@ raven==5.5.0
 django-constance[database]==1.0.1
 django-picklefield==0.3.0
 
-django-model-utils==1.4.0
-django-redis-cache==0.9.7
-redis==2.7.5
-hiredis==0.1.1
+django-model-utils==2.3.1
+django-redis-cache==1.5.3
+redis==2.10.3
+hiredis==0.2.0
 
 graypy==0.2.9

--- a/symposion/cms/managers.py
+++ b/symposion/cms/managers.py
@@ -4,6 +4,6 @@ from django.db import models
 
 class PublishedPageManager(models.Manager):
     
-    def get_query_set(self):
-        qs = super(PublishedPageManager, self).get_query_set()
+    def get_queryset(self):
+        qs = super(PublishedPageManager, self).get_queryset()
         return qs.filter(publish_date__lte=datetime.now())

--- a/symposion/urls.py
+++ b/symposion/urls.py
@@ -16,7 +16,7 @@ URL_PREFIX = settings.CONFERENCE_URL_PREFIXES[settings.CONFERENCE_ID]
 
 
 urlpatterns = patterns("",
-    url(r"^$", RedirectView.as_view(url="/%s/" % URL_PREFIX)),
+    url(r"^$", RedirectView.as_view(url="/%s/" % URL_PREFIX, permanent=True)),
     url(r"^%s/" % URL_PREFIX, include(patterns("",
         url(r"^$", TemplateView.as_view(template_name="homepage.html"),
             name="home"),


### PR DESCRIPTION
Fix some warnings, including deprecation warnings that come up
when running 'manage.py check' with django 1.7 or django 1.8,
and a 'no logging handler' warning that occurred during tests.

A lot of these just needed upgrading dependencies; a few required
small code changes.