### PR TITLE
TypeError: cannot create weak reference to 'int' object

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,8 +25,8 @@ git+git://github.com/caktus/django-sitetree.git#egg=django-sitetree
 -e git+git://github.com/shvechikov/python-rtfng.git#egg=python-rtfng
 
 django-taggit==0.15.0
-# Django-reversion 1.9.1 for Django 1.7+
-django-reversion==1.9.1
+# Django-reversion 1.9.2 for Django 1.7+
+django-reversion==1.9.2
 django-markitup==1.0.0
 Markdown==2.3.1
 django-selectable==0.9.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,7 +25,8 @@ git+git://github.com/caktus/django-sitetree.git#egg=django-sitetree
 -e git+git://github.com/shvechikov/python-rtfng.git#egg=python-rtfng
 
 django-taggit==0.15.0
-django-reversion==1.8.7
+# Django-reversion 1.9.1 for Django 1.7+
+django-reversion==1.9.1
 django-markitup==1.0.0
 Markdown==2.3.1
 django-selectable==0.9.0


### PR DESCRIPTION
Got this error.  According to Dr. Google, we need to use specific versions of django-reversion depending on what version of Django we are using, or this can happen. For Django 1.7+, that's django-reversion 1.9.1 right now (http://django-reversion.readthedocs.org/en/latest/django-versions.html#django-versions).

TypeError: cannot create weak reference to 'int' object
(6 additional frame(s) were not displayed)
...
  File "reversion/middleware.py", line 26, in _close_revision
    revision_context_manager.end()
  File "reversion/revisions.py", line 183, in end
    db = self._db,
  File "reversion/revisions.py", line 474, in save_revision
    revision.save(using=db)
  File "reversion/models.py", line 217, in check_for_receivers
    if len(sending_signal._live_receivers(_make_id(sender))) > 1:
  File "python2.7/weakref.py", line 343, in get
    return self.data.get(ref(key),default)
Request

URL	http://us.pycon.org/2016/sponsors/charityauction/_edit/