### PR TITLE
Fix fab dbshell

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -46,7 +46,7 @@ def manage_run(command):
     """Run a Django management command on the remote server."""
     if command == 'dbshell':
         # Need custom code for dbshell to work
-        exec(dbshell)
+        dbshell()
         return
     require('environment')
     manage_cmd = ("{env.virtualenv_root}/bin/python "


### PR DESCRIPTION
'fab server manage_run:dbshell' was not working. I guess there
wasn't enough information in the Django settings for Django to
invoke psql correctly to connect to our databases the way they
are set up in the PSF infrastructure.

Added a new fab task 'dbshell' that extracts the needed info
the same way we do before running a dump, and invokes psql
directly.  Also tweaked 'manage_run' so if 'dbshell' is passed
as the command, it uses the new task.