### PR TITLE
Fix social auth for Google

### DIFF
--- a/pycon/settings/server.py
+++ b/pycon/settings/server.py
@@ -26,6 +26,8 @@ ALLOWED_HOSTS = [
 
 SECRET_KEY = env_or_default('SECRET_KEY', '')
 
+SOCIAL_AUTH_REDIRECT_IS_HTTPS = True
+
 ADMINS = (
     ('Ernest W. Durbin III', 'ewdurbin@gmail.com'),
     ('Caktus Pycon Team', 'pycon@caktusgroup.com'),


### PR DESCRIPTION
Google was expecting the redirect_uri to be an https: URL.
We need to set SOCIAL_AUTH_REDIRECT_IS_HTTPS = True on servers
to make that happen.