### PR TITLE
Enable persistent database connections

### DIFF
--- a/pycon/settings/base.py
+++ b/pycon/settings/base.py
@@ -41,6 +41,8 @@ DATABASES = {
         "PASSWORD": env_or_default("DB_PASSWORD", ""),
         "HOST": env_or_default("DB_HOST", ""),
         "PORT": env_or_default("DB_PORT", ""),
+        # https://docs.djangoproject.com/en/1.8/ref/databases/#persistent-connections
+        "CONN_MAX_AGE": int(env_or_default("CONN_MAX_AGE", 300)),
     }
 }
 


### PR DESCRIPTION
Keep connections open and reuse them for up to 5 minutes
by default.

See https://docs.djangoproject.com/en/1.8/ref/databases/#persistent-connections