### PR TITLE
Fix sending tutorial emails

### DIFF
--- a/pycon/tutorials/utils.py
+++ b/pycon/tutorials/utils.py
@@ -80,8 +80,8 @@ def queue_email_message(template_name, from_, to, bcc, context, headers=None):
         subject=subject,
         body=body,
         from_address=from_,
-        to_addresses=to,
-        bcc_addresses=bcc,
+        to_addresses=list(to),
+        bcc_addresses=list(bcc),
         headers=json.dumps(headers),
     )
 


### PR DESCRIPTION
The lists of email addresses were sometimes coming into the
queue_email function as querysets, which the BulkEmail model's
MultiEmail fields couldn't handle. Force them to be lists
when creating the BulkEmail object.