### PR TITLE
Cleanup requirements slightly

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,16 +3,12 @@
 # project specific not listed here use project.txt. You can, of course, update
 # versions of distributions here if needed.
 
---extra-index-url=http://dist.pinaxproject.com/dev/
---extra-index-url=http://dist.pinaxproject.com/alpha/
---extra-index-url=http://dist.pinaxproject.com/fresh-start/
-
 Django==1.8.3
 pinax-theme-bootstrap==3.0a12
 django-user-accounts==1.1
 metron==1.3.5
-pinax-utils==1.0b1.dev3
-django-mailer==0.2a1
+http://dist.pinaxproject.com/dev/pinax-utils/pinax-utils-1.0b1.dev3.tar.gz#egg=pinax-utils
+http://dist.pinaxproject.com/alpha/django-mailer/django-mailer-0.2a1.tar.gz#egg=django-mailer
 django-timezones==0.2
 pytz==2014.4
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ basepython = python2.7
 setenv = PYTHON_PATH = {toxinidir}
     DJANGO_SETTINGS_MODULE = pycon.settings.test
 commands = {envpython} manage.py test --noinput {posargs}
-install_command=pip install -U --trusted-host dist.pinaxproject.com {opts} {packages}
+install_command=pip install -U {opts} {packages}
 
 [testenv:pycon]
 deps = {[default]deps}


### PR DESCRIPTION
Remove insecure extra index URLs from dist.pinaxproject.com
from our requirements files. This always made pip, tox, and
now Read The Docs unhappy. By replacing two package names
in the requirements with direct links to their tarballs
(still on dist.pinaxproject.com), we can get rid of the errors
and warnings.