### PR TITLE
Add more help to URL field

### DIFF
--- a/pycon/sponsorship/migrations/0011_auto_20150824_0859.py
+++ b/pycon/sponsorship/migrations/0011_auto_20150824_0859.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sponsorship', '0010_remove_more_benefits'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='sponsor',
+            name='display_url',
+            field=models.CharField(default=b'', max_length=200, verbose_name='Link text - text to display on link to sponsor page, if different from the actual link', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='sponsor',
+            name='external_url',
+            field=models.URLField(help_text='(Must include https:// or http://.)', verbose_name='Link to sponsor web page'),
+        ),
+    ]

--- a/pycon/sponsorship/models.py
+++ b/pycon/sponsorship/models.py
@@ -65,8 +65,16 @@ class Sponsor(models.Model):
     applicant = models.ForeignKey(User, related_name="sponsorships", verbose_name=_("applicant"), null=True, on_delete=SET_NULL)
 
     name = models.CharField(_("Sponsor Name"), max_length=100)
-    display_url = models.URLField(_("Link text - text to display on link to sponsor page, if different from the actual link"), blank=True)
-    external_url = models.URLField(_("Link to sponsor web page"))
+    display_url = models.CharField(
+        _("Link text - text to display on link to sponsor page, if different from the actual link"),
+        max_length=200,
+        default='',
+        blank=True
+    )
+    external_url = models.URLField(
+        _("Link to sponsor web page"),
+        help_text=_("(Must include https:// or http://.)")
+    )
     annotation = models.TextField(_("annotation"), blank=True)
     contact_name = models.CharField(_("Contact Name"), max_length=100)
     contact_emails = MultiEmailField(


### PR DESCRIPTION
On sponsor page, add help to say that the URL must include
http:// or https://.

Also noticed that the "display_url" field, which doesn't
really have to be a URL (it's just used for display), was
a URLField, so changed that to a CharField so sponsors
can just put in "python.org" or something if they prefer
that to "https://python.org".