### PR TITLE
Add box on venues page above hotels

### DIFF
--- a/pycon/templates/venue/detail.html
+++ b/pycon/templates/venue/detail.html
@@ -20,6 +20,8 @@
   <div class="hotels">
     <h2><i class="icon icon-home"></i> {% trans "Hotels" %}</h2>
 
+    {% box "hotels_intro" %}
+
     <div class="row-fluid">
       <div class="place span4">{% box "hotel-1" %}</div>
       <div class="place span4">{% box "hotel-2" %}</div>


### PR DESCRIPTION
Empty box will allow adding introductory text
above the hotel data.