### PR TITLE
Move staff email addresses to settings

### DIFF
--- a/docs/finaid.rst
+++ b/docs/finaid.rst
@@ -4,13 +4,10 @@ Financial Aid
 Settings
 --------
 
-Create a FINANCIAL_AID setting in Django settings. It should be a dictionary.
-Values can include:
-
-    email
-        The email address that messages related to financial aid come from,
-        and that users should email with questions. Defaults to
-        ``pycon-aid@python.org``.
+Create a FINANCIAL_AID_EMAIL setting in Django settings with the email
+address that messages related to financial aid come from,
+and that users should email with questions. Defaults to
+``pycon-aid@python.org``.
 
 
 To enable applications, use the admin to create new

--- a/pycon/context_processors.py
+++ b/pycon/context_processors.py
@@ -4,4 +4,5 @@ from django.conf import settings
 def global_settings(request):
     return {
         'CONFERENCE_YEAR': settings.CONFERENCE_YEAR,
+        'REGISTRATION_EMAIL': settings.REGISTRATION_EMAIL,
     }

--- a/pycon/finaid/tests/test_utils.py
+++ b/pycon/finaid/tests/test_utils.py
@@ -1,19 +1,16 @@
 """Test for the finaid.utils package"""
 
 import datetime
-import unittest
 
 from mock import patch
 
-from django.conf import settings
 from django.core import mail
 from django.contrib.auth.models import User, AnonymousUser
 from django.template import Template
 from django.test import TestCase
 
 from ..models import FinancialAidApplication, FinancialAidApplicationPeriod
-from ..utils import DEFAULT_EMAIL_ADDRESS, applications_open, \
-    email_address, has_application, send_email_message
+from ..utils import applications_open, has_application, send_email_message
 
 
 today = datetime.date.today()
@@ -30,7 +27,7 @@ class TestFinAidUtils(TestCase):
 
     def test_has_application_true(self):
         user = User.objects.create_user('joe')
-         # Just the minimum required fields
+        # Just the minimum required fields
         FinancialAidApplication.objects.create(
             user=user,
             profession="Foo",
@@ -102,26 +99,9 @@ class TestFinAidUtils(TestCase):
         )
         self.assertTrue(applications_open())
 
-    def test_email_address_default(self):
-        # If not set, email address is the default.
-        # Set dummy FINANCIAL_AID just so we can delete the setting, and
-        # be sure it'll be restored to its pre-test value when we're
-        # done.
-        expected = DEFAULT_EMAIL_ADDRESS
-        with self.settings(FINANCIAL_AID_EMAIL=None):
-            # no settings at all
-            delattr(settings, 'FINANCIAL_AID_EMAIL')
-            self.assertEqual(expected, email_address())
-
-    def test_email_address_override(self):
-        # settings can override email address
-        expected = "foo@example.com"
-        with self.settings(FINANCIAL_AID_EMAIL=expected):
-            self.assertEqual(expected, email_address())
-
 
 @patch('pycon.finaid.utils.get_template')
-class TestSendEmailMessage(unittest.TestCase):
+class TestSendEmailMessage(TestCase):
     # def send_email_message(template_name, from_, to, context, header=None):
 
     def test_send_email_message(self, get_template):

--- a/pycon/finaid/tests/test_utils.py
+++ b/pycon/finaid/tests/test_utils.py
@@ -108,18 +108,15 @@ class TestFinAidUtils(TestCase):
         # be sure it'll be restored to its pre-test value when we're
         # done.
         expected = DEFAULT_EMAIL_ADDRESS
-        with self.settings(FINANCIAL_AID=None):
+        with self.settings(FINANCIAL_AID_EMAIL=None):
             # no settings at all
-            delattr(settings, 'FINANCIAL_AID')
-            self.assertEqual(expected, email_address())
-            # email entry not set
-            settings.FINANCIAL_AID = {}
+            delattr(settings, 'FINANCIAL_AID_EMAIL')
             self.assertEqual(expected, email_address())
 
     def test_email_address_override(self):
         # settings can override email address
         expected = "foo@example.com"
-        with self.settings(FINANCIAL_AID={'email': expected}):
+        with self.settings(FINANCIAL_AID_EMAIL=expected):
             self.assertEqual(expected, email_address())
 
 

--- a/pycon/finaid/utils.py
+++ b/pycon/finaid/utils.py
@@ -59,10 +59,9 @@ def email_address():
     applications should send emails to with questions, etc.
 
     Default is ``pycon-aid@python.org``. Override by setting
-    FINANCIAL_AID['email'].
+    FINANCIAL_AID_EMAIL.
     """
-    return getattr(settings, "FINANCIAL_AID", {})\
-        .get('email', DEFAULT_EMAIL_ADDRESS)
+    return getattr(settings, "FINANCIAL_AID_EMAIL", DEFAULT_EMAIL_ADDRESS)
 
 
 def email_context(request, application, message=None):

--- a/pycon/settings/base.py
+++ b/pycon/settings/base.py
@@ -56,7 +56,6 @@ ADMINS = [
 
 MANAGERS = ADMINS
 
-THEME_CONTACT_EMAIL = 'pycon-reg@python.org'
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
@@ -321,7 +320,6 @@ GOOGLE_OAUTH2_CLIENT_SECRET = env_or_default('GOOGLE_OAUTH2_CLIENT_SECRET', '')
 
 EMAIL_CONFIRMATION_DAYS = 2
 EMAIL_DEBUG = DEBUG
-DEFAULT_FROM_EMAIL = "PyCon {} <no-reply@us.pycon.org>".format(CONFERENCE_YEAR)
 
 DEBUG_TOOLBAR_CONFIG = {
     "INTERCEPT_REDIRECTS": False,
@@ -416,3 +414,12 @@ CELERYBEAT_SCHEDULE = {
         'schedule': timedelta(minutes=5),
     }
 }
+
+# EMAIL ADDRESSES
+# Override in more specific settings files, please.
+DEFAULT_FROM_EMAIL = 'pycon@caktusgroup.com'
+FINANCIAL_AID_EMAIL = 'pycon@caktusgroup.com'
+ORGANIZERS_EMAIL = 'pycon@caktusgroup.com'
+REGISTRATION_EMAIL = 'pycon@caktusgroup.com'
+SPONSORSHIP_EMAIL = 'pycon@caktusgroup.com'
+THEME_CONTACT_EMAIL = 'pycon@caktusgroup.com'

--- a/pycon/settings/base.py
+++ b/pycon/settings/base.py
@@ -291,7 +291,7 @@ SOCIAL_AUTH_ASSOCIATE_BY_MAIL = False
 # Don't clobber User.email if someone associates a social account that
 # happens to have a different email address
 # http://django-social-auth.readthedocs.org/en/latest/configuration.html#miscellaneous-settings
-SOCIAL_AUTH_PROTECTED_USER_FIELDS = ['email',]
+SOCIAL_AUTH_PROTECTED_USER_FIELDS = ['email']
 
 # To get the Google OAuth2 Client ID and Secret:
 #
@@ -392,7 +392,7 @@ TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
 # Need to switch from the now-default JSON serializer, or OAuth2 breaks trying
 # to serialize a datetime to JSON
-SESSION_SERIALIZER='django.contrib.sessions.serializers.PickleSerializer'
+SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 
 
 # Celery

--- a/pycon/settings/production.py
+++ b/pycon/settings/production.py
@@ -3,7 +3,12 @@ from .server import *
 
 # From address for production
 DEFAULT_FROM_EMAIL = "PyCon %s <no-reply@us.pycon.org>" % CONFERENCE_YEAR
+FINANCIAL_AID_EMAIL = "pycon-aid@python.org"
+ORGANIZERS_EMAIL = 'pycon-organizers@python.org'
+REGISTRATION_EMAIL = 'pycon-reg@python.org'
 SERVER_EMAIL = DEFAULT_FROM_EMAIL
+SPONSORSHIP_EMAIL = 'pycon-sponsors@python.org'
+THEME_CONTACT_EMAIL = 'pycon-reg@python.org'
 
 LOGGING['filters']['static_fields']['fields']['environment'] = 'production'
 

--- a/pycon/sponsorship/models.py
+++ b/pycon/sponsorship/models.py
@@ -1,5 +1,7 @@
 import datetime
+from django.conf import settings
 
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.db import models
@@ -262,7 +264,7 @@ def _send_admin_email(sender, instance, created, **kwargs):
     """
     if created:
         send_email(
-            to=['pycon-sponsors@python.org'],
+            to=[settings.SPONSORSHIP_EMAIL],
             kind='new_sponsor',
             context={
                 'sponsor': instance,

--- a/pycon/templates/site_base.html
+++ b/pycon/templates/site_base.html
@@ -190,7 +190,7 @@
                 <div class="span6">
                   <p>
                     {% blocktrans %}
-                      Questions? Comments? Contact <a href="mailto:pycon-reg@python.org">pycon-reg@python.org</a></br>
+                      Questions? Comments? Contact <a href="mailto:{{ REGISTRATION_EMAIL }}">{{ REGISTRATION_EMAIL }}</a></br>
                     {% endblocktrans %}
                   </p>
                   <div class="footer-center">

--- a/symposion/templates/500.html
+++ b/symposion/templates/500.html
@@ -22,7 +22,7 @@
                 Oops, we've had a problem on the server. The web team have been informed and will be looking into it but if you have any questions, don't hesitate to email:
             </p>
 
-            <p><a href="mailto:pycon-reg@python.org"><em>pycon-reg@python.org</em></a></p>
+            <p><a href="mailto:{{ REGISTRATION_EMAIL }}"><em>{{ REGISTRATION_EMAIL }}</em></a></p>
         </div>
     </body>
 </html>

--- a/symposion/templates/site_base.html
+++ b/symposion/templates/site_base.html
@@ -126,7 +126,7 @@
                 <br />
                     Site built by <a href="http://caktusgroup.com">Caktus Consulting Group, LLC.</a> using <a href="http://pinaxproject.com/symposion/" title="Symposion — An Open Platform for Conference Websites">Symposion</a>. Hosting provided by <a href="http://osuosl.org">OSU Open Source Lab</a>.
                 <br />
-                    Questions? Comments? Contact <a href="mailto:pycon-reg@python.org">pycon-reg@python.org</a>
+                    Questions? Comments? Contact <a href="mailto:{{ REGISTRATION_EMAIL }}">{{ REGISTRATION_EMAIL }}</a>
                 </p>
             {% endblock %}
         </footer>


### PR DESCRIPTION
We have a number of email addresses embedded in the code that are sent emails on events (like a new sponsor application being submitted).  The financial aid application makes provision to override the default address using settings, but we're not using that.

The result is probably that the people at the other end of these addresses are getting emailed as we do our testing on local systems and the staging site, and have to ignore these test messages.

We should have all these addresses in settings, and only point them at the real addresses for production. The others should either go nowhere or to the development team by default.