### PR TITLE
change span10 to span9

### DIFF
--- a/symposion/templates/reviews/base.html
+++ b/symposion/templates/reviews/base.html
@@ -117,7 +117,7 @@
                     </ul>
                 {% endblock %}
             </div>
-            <div class="span10">
+            <div class="span9">
                 {% block body %}
                 {% endblock %}
             </div>


### PR DESCRIPTION
It seems that `<div class="span2">` and `<div class="span10">` were too wide for one row, so the second div was being pushed down below the first div.

Fixes #482 