### PR TITLE
517 Fix formatting of finaid confirm buttons

### DIFF
--- a/pycon/templates/finaid/confirm.html
+++ b/pycon/templates/finaid/confirm.html
@@ -5,6 +5,6 @@
     {% csrf_token %}
     <p>{{ message }}</p>
     <button class="btn btn-primary" type="submit">{% trans "Yes" %}</button>
-    <a class="btn btn-default" href="{% url 'dashboard' %}">{% trans "No" %}</a>
+    <a href="{% url 'dashboard' %}"><button class="btn btn-default">{% trans "No" %}</button></a>
   </form>
 {% endblock body %}


### PR DESCRIPTION
Hovering over the "No" button was causing the
"Yes" button to move slightly. Changed the "No"
button to be an actual button wrapped in a link,
rather than just a button-styled link, and that
seemed to fix it.

Fixes #517