### PR TITLE
Nav and CMS Fixes

### DIFF
--- a/pycon/static/less/site.less
+++ b/pycon/static/less/site.less
@@ -427,7 +427,7 @@ footer {
   }
   img {
     width: 20%;
-    height: 64px;
+    height: 65px;
     top: 0;
     float: left;
     position: relative;
@@ -668,26 +668,7 @@ header.main {
     background: @blueSky;
     @media (min-width: @breakDesktop) {
       margin-top: 1.5em;
-      padding-left: 20%;
       font-family: 'Roboto Condensed', Helvetica, Arial, sans-serif;
-    }
-    a.logo-small {
-      position:absolute;
-      top: 5px;
-      left: 0;
-      width: 110px;
-      height: 70px;
-      background:url(../img/PNG/pycon16-logo-small.png) no-repeat 0 0;
-      background-size: 110px auto;
-      text-indent: -9999px;
-      border-bottom: none;
-      @media (min-width: @breakDesktop) {
-        top: 15px;
-        left: 5%;
-      }
-      @media (max-width: @breakDesktop) {
-          display: none;
-      }
     }
     @media (min-width: @breakDesktop) {
       ul {
@@ -740,11 +721,6 @@ header.main {
               .caret {
                 border-top-color: @maroon;
               }
-              &:hover {
-                .caret {
-                  border-top-color: white;
-                }
-              }
               a {
                 padding: 1em;
                 border-radius: 0;
@@ -752,6 +728,9 @@ header.main {
                 &:hover {
                   color: white;
                   background-color: @maroon;
+                  .caret {
+                    border-top-color: white;
+                  }
                 }
               }
             }
@@ -759,10 +738,38 @@ header.main {
         }
       }
 
+      .nav > li.dropdown > a {
+        padding-right: 0;
+      }
+
       .nav {
         margin: 0;
+        @media (min-width: @breakDesktop) {
+          padding-left: 20%;
+          width: 80%;
+        }
         li {
-           a {
+          border-bottom: 2px solid transparent;
+          &:hover {
+            color: @maroon;
+            border-bottom: 2px solid @maroon;
+            .transition(0.25s);
+          }
+          &.active {
+            border-bottom: 2px solid @maroon;
+          }
+          &:focus {
+            .caret {
+              border-top-color: @maroon;
+            }
+          }
+          &.open {
+            border-bottom: none;
+          }
+          @media (min-width: @breakDesktop) {
+            margin-right: 1em;
+          }
+          a {
             font-size: @baseFontSize + 3;
             font-weight:400;
             margin: 0 0 0 0 !important;
@@ -770,26 +777,7 @@ header.main {
             box-shadow: none !important;
             text-shadow: none;
             color: @maroon;
-            font-weight: 400;
-            border-bottom: 1px solid transparent;
-            @media (min-width: @breakDesktop) {
-              padding-right: 1em;
-            }
-            &:hover {
-              color: @maroon;
-              border-bottom: 2px solid @maroon;
-              .transition(0.35s);
-              &:focus {
-              }
-            }
-            &:active {
-              border-bottom: 2px solid @maroon;
-            }
-            &:focus {
-              .caret {
-                border-top-color: @maroon;
-              }
-            }
+            border-bottom: none;
           }
           &.dropdown {
             ul {
@@ -816,7 +804,6 @@ header.main {
         li.dropdown.active {
           a {
             color: @maroon;
-            border-bottom: 2px solid @maroon;
           }
           .caret {
             border-top-color: @maroon;
@@ -847,6 +834,7 @@ header.main {
             }
           }
           li {
+            margin-right: 0;
             &.active {
               a {
                 color: @maroon;
@@ -860,12 +848,20 @@ header.main {
               @media (max-width: @breakDesktop) {
                 padding-left: 2em !important;
               }
+
               &:hover,
-              &:active,
+              &:focus,
+              &.active {
+                background-image: none;
+              }
+
+              &:hover,
               &:focus {
+                background-color: white;
+              }
+              &.active {
                 background-color: @maroon;
                 color: @white;
-                background-image: none;
               }
             }
           }
@@ -891,6 +887,7 @@ header.main {
     position: relative;
     background-color: white;
     @media (min-width: @breakDesktop) {
+      width: 100%;
       margin: 0;
       float: right;
       position: absolute;
@@ -901,23 +898,56 @@ header.main {
       z-index: 1;
     }
     &.loggedin {
+      color: white;
+      background-color: @maroon;
+      .account-links {
+        padding-top: 0.75em;
+        @media (min-width: @breakDesktop) {
+          padding-top: 0;
+        }
+        span,
+        a {
+          margin: 0 6px;
+          color: white;
+          border-bottom: none;
+        }
+        span { margin-left: 1em; }
+        a.logo-small { top: 3.5em; }
+      }
       @media (min-width: @breakDesktop) {
         position: relative;
-      }
-      span {
-        margin-left: 1em;
-        @media (min-width: @breakDesktop) {
-          margin-left: 0;
-        }
+
+        span { margin-left: 0; }
       }
     }
     .account-links {
+      @media (min-width: @breakDesktop) {
+        float: right;
+      }
+      a.logo-small {
+        position:absolute;
+        top: 5px;
+        left: 0;
+        width: 110px;
+        height: 70px;
+        background:url(../img/PNG/pycon16-logo-small.png) no-repeat 0 0;
+        background-size: 110px auto;
+        text-indent: -9999px;
+        border-bottom: none;
+        @media (min-width: @breakDesktop) {
+          top: 15px;
+          left: 5%;
+        }
+        @media (max-width: @breakDesktop) {
+            display: none;
+        }
+      }
       button.logout,
       a {
         &.login,
         &.logout,
         &.signup {
-          padding: 1.75em 1.5em !important;
+          padding: 1.75em 1em !important;
           height: 100%;
           border-radius: 0;
           background-color: @red;
@@ -933,7 +963,11 @@ header.main {
           @media (min-width: @breakDesktop) {
             display: inline-block;
             text-align: center;
+            padding: 1.75em 1.5em !important;
           }
+        }
+        @media (min-width: @breakDesktop) {
+          &.logout { padding: .75em 1.5em !important; }
         }
       }
     }

--- a/pycon/static/less/site.less
+++ b/pycon/static/less/site.less
@@ -665,15 +665,12 @@ header.main {
     border-top-color: @maroon;
   }
   nav {
-    background: @blueSky;
     @media (min-width: @breakDesktop) {
       margin-top: 1.5em;
       font-family: 'Roboto Condensed', Helvetica, Arial, sans-serif;
-    }
-    @media (min-width: @breakDesktop) {
       ul {
         width: 100%;
-        z-index: 0;
+        z-index: 1;
       }
     }
     .container {
@@ -713,25 +710,19 @@ header.main {
           padding: 0;
           .nav-collapse .nav {
             background-color: white;
+            padding: 0 1em;
             li.dropdown .dropdown-toggle:hover {
-              background-color: @maroon;
-              color: white;
+              background-color: white;
+              color: @maroon;
             }
             li {
               .caret {
                 border-top-color: @maroon;
               }
               a {
-                padding: 1em;
+                padding: 1em 0;
                 border-radius: 0;
                 display: block;
-                &:hover {
-                  color: white;
-                  background-color: @maroon;
-                  .caret {
-                    border-top-color: white;
-                  }
-                }
               }
             }
           }
@@ -745,7 +736,7 @@ header.main {
       .nav {
         margin: 0;
         @media (min-width: @breakDesktop) {
-          padding-left: 20%;
+          left: 20%;
           width: 80%;
         }
         li {
@@ -763,9 +754,6 @@ header.main {
               border-top-color: @maroon;
             }
           }
-          &.open {
-            border-bottom: none;
-          }
           @media (min-width: @breakDesktop) {
             margin-right: 1em;
           }
@@ -776,8 +764,13 @@ header.main {
             padding: .5em .5em .5em 0;
             box-shadow: none !important;
             text-shadow: none;
-            color: @maroon;
+            color: @maroon !important;
             border-bottom: none;
+            &:hover {
+              @media (max-width: @breakDesktop) {
+                background-color: white;
+              }
+            }
           }
           &.dropdown {
             ul {
@@ -810,9 +803,20 @@ header.main {
           }
         }
 
+        li.dropdown.active.open {
+          border-bottom: none;
+        }
+
+        li.open > a {
+          border-bottom: 2px solid @maroon;
+          &:hover {
+            border-bottom: 2px solid @maroon;
+          }
+        }
+
         .dropdown-menu {
           margin: 8px 0 0 0;
-          padding: 0;
+          padding: 0 1.3em;
           .transition(0.35s);
           border: 0;
           border-radius: 2px;
@@ -826,7 +830,6 @@ header.main {
           }
           @media (max-width: @breakDesktop) {
             margin: 0;
-            background-color: darken(@tanCity, 4%)
           }
           &:last-child {
             @media (max-width: @breakDesktop) {
@@ -835,6 +838,7 @@ header.main {
           }
           li {
             margin-right: 0;
+            max-width: 300px;
             &.active {
               a {
                 color: @maroon;
@@ -844,9 +848,9 @@ header.main {
             a {
               margin: 0;
               color: @grayDark;
-              padding: 1em 1.75em;
+              padding: 1em 0;
               @media (max-width: @breakDesktop) {
-                padding-left: 2em !important;
+                padding-left: 0 !important;
               }
 
               &:hover,
@@ -869,18 +873,6 @@ header.main {
       }
     }
   }
-  @media (max-width: @breakDesktop) {
-    .navbar-inverse .nav li.dropdown.open > a.dropdown-toggle {
-      background-color: @maroon;
-      color: white;
-      .caret {
-        border-top-color: white;
-      }
-    }
-    header.main nav .navbar .navbar-inner .nav-collapse .nav li.dropdown.open ul a {
-      padding-left: 2em;
-    }
-  }
   .account-bar {
     float: none;
     text-transform: capitalize;
@@ -895,11 +887,11 @@ header.main {
       right: 0;
       background-color: transparent;
       padding: 0;
-      z-index: 1;
+      z-index: 0;
     }
     &.loggedin {
       color: white;
-      background-color: @maroon;
+      background-color: #91CAD4;
       .account-links {
         padding-top: 0.75em;
         @media (min-width: @breakDesktop) {
@@ -1051,6 +1043,7 @@ body.home {
         @media (min-width: @breakDesktop) {
           width: 92%;
           margin-left: 8%;
+          left: 0;
         }
       }
       .navbar-inner {
@@ -1137,10 +1130,13 @@ body.home {
   ==================== */
   .landing-hills {
     margin-left: 0 !important;
-    .hills img {
-      min-width: 100%;
-      height: auto;
-      margin-right: -30px;
+    .hills {
+      overflow: hidden;
+      img {
+        min-width: 101%;
+        height: auto;
+        margin-right: -30px;
+      }
     }
   }
 

--- a/pycon/static/less/site.less
+++ b/pycon/static/less/site.less
@@ -737,7 +737,7 @@ header.main {
         margin: 0;
         @media (min-width: @breakDesktop) {
           left: 20%;
-          width: 80%;
+          width: 62%;
         }
         li {
           border-bottom: 2px solid transparent;
@@ -1041,7 +1041,6 @@ body.home {
       .nav {
         margin: 0;
         @media (min-width: @breakDesktop) {
-          width: 92%;
           margin-left: 8%;
           left: 0;
         }

--- a/pycon/templates/_account_bar.html
+++ b/pycon/templates/_account_bar.html
@@ -3,6 +3,9 @@
 {% load i18n %}
 
 <div class="account-links">
+
+  <a class="logo-small" href="{% url 'home' %}">{{ SITE_NAME }} in Portland, Or</a>
+
     {% if user.is_authenticated %}
         {% if request.user.get_full_name%}
             <span>

--- a/pycon/templates/site_base.html
+++ b/pycon/templates/site_base.html
@@ -61,7 +61,7 @@
 
         {% block main_nav %}
             <nav>
-                <a class="logo-small" href="{% url 'home' %}">{{ SITE_NAME }} in Portland, Or</a>
+                <!--<a class="logo-small" href="{% url 'home' %}">{{ SITE_NAME }} in Portland, Or</a>-->
 
                 <div class="navbar navbar-inverse">
                     <div class="navbar-inner">


### PR DESCRIPTION
* [ ] Explore better solution for the account bar on desktop sized screens. I made the account bar a full width bar to distinguish it from the other navigation content.
* [ ] The active nav items' underline extends past the copy. It should end at the last letter of the nav item.
* [ ] Active nav item adds a bottom border to all it's child LIs. Make sure it's only the main nav LI that gets the bottom border on hover/active.
* [ ] On the CMS page, the hills image to the left of the breadcrumbs is a little shorter than the breadcrumb container.