### PR TITLE
539 Fix exception creating edusummit proposal

### DIFF
--- a/pycon/__init__.py
+++ b/pycon/__init__.py
@@ -3,3 +3,6 @@ from __future__ import absolute_import
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
 from .celery import app as celery_app
+
+# Django's own startup stuff...
+default_app_config = 'pycon.pyconapp.PyConConfig'

--- a/pycon/admin.py
+++ b/pycon/admin.py
@@ -6,7 +6,7 @@ from markedit.admin import MarkEditAdmin
 from pycon.models import (PyConProposalCategory, PyConSponsorTutorialProposal,
                           PyConTalkProposal, PyConTutorialProposal,
                           PyConPosterProposal, PyConLightningTalkProposal,
-                          PyConOpenSpaceProposal, SpecialEvent)
+                          PyConOpenSpaceProposal, SpecialEvent, EduSummitTalkProposal)
 
 
 class ProposalMarkEditAdmin(MarkEditAdmin):
@@ -157,6 +157,7 @@ admin.site.register(PyConPosterProposal, PosterAdmin)
 admin.site.register(PyConOpenSpaceProposal, OpenSpaceAdmin)
 admin.site.register(PyConSponsorTutorialProposal, SponsorTutorialAdmin)
 admin.site.register(PyConLightningTalkProposal, LightningTalkAdmin)
+admin.site.register(EduSummitTalkProposal)
 admin.site.register(SpecialEvent, SpecialEventAdmin)
 
 

--- a/pycon/pyconapp.py
+++ b/pycon/pyconapp.py
@@ -1,6 +1,9 @@
-from sitetree.sitetreeapp import register_i18n_trees
+from django.apps import AppConfig
 
 
-class PyCon(object):
-    def __init__(self):
-        register_i18n_trees(['main'])
+class PyConConfig(AppConfig):
+    name = 'pycon'
+
+    def ready(self):
+        # Import forms so they get registered with our proposal kind registry
+        from . import forms  # noqa

--- a/symposion/proposals/kinds.py
+++ b/symposion/proposals/kinds.py
@@ -33,11 +33,17 @@ def register_proposal_form(kind_slug, form_class):
 
 
 def get_proposal_model(kind_slug):
-    return _get_tracker(kind_slug).model_class
+    model_class = _get_tracker(kind_slug).model_class
+    if not model_class:
+        raise ValueError("No model_class has been registered for proposal kind %r" % kind_slug)
+    return model_class
 
 
 def get_proposal_form(kind_slug):
-    return _get_tracker(kind_slug).form_class
+    form_class = _get_tracker(kind_slug).form_class
+    if not form_class:
+        raise ValueError("No form class has been registered for proposal kind %r" % kind_slug)
+    return form_class
 
 
 def get_proposal_model_from_section_slug(section_slug):


### PR DESCRIPTION
This happened because the forms for the proposal types
don't get registered with our new proposal type registry
until the forms.py file containing them is imported, and
that wasn't happening at startup.

Added a proper Django application initialization that
does the import at startup.

(Note: some code previously in pyconapp.py was removed; it does not seem to ever have been called from anywhere, and adding it to the new `ready` method increased the number of queries on our reviews page view, I guess because it triggered sitetree to do more work on each page. I figured if things were working fine without it, we didn't need it.)

Fixes: #539