### PR TITLE
allow receipt image to be a pdf by making it a FileField

### DIFF
--- a/pycon/finaid/forms.py
+++ b/pycon/finaid/forms.py
@@ -1,4 +1,3 @@
-import os
 from django import forms
 from django.forms import Textarea, Select
 from django.utils.translation import ugettext_lazy as _
@@ -98,12 +97,10 @@ class ReceiptForm(forms.ModelForm):
         """We require the receipt image field to be the correct format."""
         cleaned_data = super(ReceiptForm, self).clean()
         receipt_field = cleaned_data.get("receipt_image")
-        accepted_formats = ['.bmp', '.jpeg', '.jpg', '.png', '.pdf']
         if receipt_field is not None:
-            if os.path.splitext(receipt_field.file.name)[1] not in accepted_formats:
-                raise forms.ValidationError(
-                    "File format was not accepted. The only acceptable formats "
-                    "are: .bmp, .jpeg, .jpg, .png, .pdf.")
+            # Make sure that the receipt image field can be converted to python
+            # This does validation based on the field type (ImageField or FileField)
+            self.fields['receipt_image'].to_python(receipt_field)
         else:
             raise forms.ValidationError("No receipt image uploaded.")
 

--- a/pycon/finaid/forms.py
+++ b/pycon/finaid/forms.py
@@ -93,17 +93,6 @@ class BulkEmailForm(forms.Form):
 
 
 class ReceiptForm(forms.ModelForm):
-    def clean(self, *args, **kwargs):
-        """We require the receipt image field to be the correct format."""
-        cleaned_data = super(ReceiptForm, self).clean()
-        receipt_field = cleaned_data.get("receipt_image")
-        if receipt_field is not None:
-            # Make sure that the receipt image field can be converted to python
-            # This does validation based on the field type (ImageField or FileField)
-            self.fields['receipt_image'].to_python(receipt_field)
-        else:
-            raise forms.ValidationError("No receipt image uploaded.")
-
     class Meta:
         model = Receipt
         fields = ["description", "amount", "receipt_image"]

--- a/pycon/finaid/forms.py
+++ b/pycon/finaid/forms.py
@@ -1,5 +1,5 @@
+import os
 from django import forms
-from django.core.exceptions import ValidationError
 from django.forms import Textarea, Select
 from django.utils.translation import ugettext_lazy as _
 
@@ -94,6 +94,19 @@ class BulkEmailForm(forms.Form):
 
 
 class ReceiptForm(forms.ModelForm):
+    def clean(self, *args, **kwargs):
+        """We require the receipt image field to be the correct format."""
+        cleaned_data = super(ReceiptForm, self).clean()
+        receipt_field = cleaned_data.get("receipt_image")
+        accepted_formats = ['.bmp', '.jpeg', '.jpg', '.png', '.pdf']
+        if receipt_field is not None:
+            if os.path.splitext(receipt_field.file.name)[1] not in accepted_formats:
+                raise forms.ValidationError(
+                    "File format was not accepted. The only acceptable formats "
+                    "are: .bmp, .jpeg, .jpg, .png, .pdf.")
+        else:
+            raise forms.ValidationError("No receipt image uploaded.")
+
     class Meta:
         model = Receipt
         fields = ["description", "amount", "receipt_image"]

--- a/pycon/finaid/migrations/0009_auto_20150917_1629.py
+++ b/pycon/finaid/migrations/0009_auto_20150917_1629.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import pycon.finaid.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('finaid', '0008_auto_20150916_0848'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='receipt',
+            name='receipt_image',
+            field=models.FileField(upload_to=pycon.finaid.models.user_directory_path),
+        ),
+    ]

--- a/pycon/finaid/models.py
+++ b/pycon/finaid/models.py
@@ -308,4 +308,4 @@ class Receipt(models.Model):
         verbose_name=_("Amount"),
         help_text=_("Please enter the amount of the receipt in US dollars."),
         decimal_places=2, max_digits=8, default=Decimal("0.00"))
-    receipt_image = models.ImageField(upload_to=user_directory_path)
+    receipt_image = models.FileField(upload_to=user_directory_path)

--- a/pycon/finaid/models.py
+++ b/pycon/finaid/models.py
@@ -294,7 +294,7 @@ def user_directory_path(instance, filename):
     https://docs.djangoproject.com/en/1.7/topics/migrations/#serializing-values
     """
     # file will be uploaded to MEDIA_ROOT/finaid_receipts/<user>/<filename>
-    return 'finaid_receipts/{}/{}'.format(instance.user.username, filename)
+    return 'finaid_receipts/{}/{}'.format(instance.application.user.username, filename)
 
 
 class Receipt(models.Model):
@@ -303,7 +303,7 @@ class Receipt(models.Model):
                                     related_name="receipts")
 
     description = models.CharField(max_length=255,
-        help_text="Please enter a description of this receipt image.")
+                                   help_text="Please enter a description of this receipt image.")
     amount = models.DecimalField(
         verbose_name=_("Amount"),
         help_text=_("Please enter the amount of the receipt in US dollars."),

--- a/pycon/finaid/tests/test_forms.py
+++ b/pycon/finaid/tests/test_forms.py
@@ -2,8 +2,8 @@ import datetime
 import StringIO
 
 from django.contrib.auth.models import User
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
-from django.core.files.base import ContentFile
 
 from ..models import FinancialAidApplication, FinancialAidMessage,\
     PYTHON_EXPERIENCE_BEGINNER, Receipt
@@ -86,58 +86,49 @@ class TestReceiptForm(TestCase):
         )
         self.application.save()
 
-    def test_valid_receipt(self):
-        """Checks form is valid with SimpleUploadeFile extension pdf or png."""
+    def test_valid_receipt_png(self):
+        """Checks form is valid with SimpleUploadeFile extension png."""
         # Use StringIO to create files
         png_file = StringIO.StringIO('portable network graphics file')
-        pdf_file = StringIO.StringIO('portable document format file')
         # Use PIL Image to create new png and pdf files
         Image.new('RGB', size=(50, 50), color=(256, 0, 0)).save(png_file, 'png')
-        Image.new('RGB', size=(50, 50), color=(256, 0, 0)).save(pdf_file, 'pdf')
         png_file.seek(0)
-        pdf_file.seek(0)
         # Django-friendly ContentFiles
-        django_friendly_png_file = ContentFile(png_file.read(), 'test_file.png')
-        django_friendly_pdf_file = ContentFile(pdf_file.read(), 'test_file.pdf')
-        # Create receipts with these files in the receipt_image field
-        receipt_png = Receipt(
-            application=self.application,
-            description='description png',
-            amount=1,
-            receipt_image=django_friendly_png_file)
-        receipt_pdf = Receipt(
-            application=self.application,
-            description='description pdf',
-            amount=1,
-            receipt_image=django_friendly_pdf_file)
-        receipt_png.user = self.user
-        receipt_pdf.user = self.user
-        # Save the receipts
-        receipt_png.save()
-        receipt_pdf.save()
+        file = SimpleUploadedFile('test_file.png', png_file.read())
         # Data for the form
         data_png = {'description': 'description png',
                     'amount': 1,
-                    'receipt_image': django_friendly_png_file}
+                    }
+        files = {'receipt_image': file}
+
+        form_png = ReceiptForm(data_png, files, instance=Receipt(application=self.application))
+
+        self.assertTrue(form_png.is_valid(), msg=form_png.errors)
+        form_png.save()
+
+    def test_valid_receipt_pdf(self):
+        """Checks form is valid with SimpleUploadeFile extension pdf"""
+        # Use StringIO to create files
+        pdf_file = StringIO.StringIO('portable document format file')
+        # Use PIL Image to create new png and pdf files
+        Image.new('RGB', size=(50, 50), color=(256, 0, 0)).save(pdf_file, 'pdf')
+        pdf_file.seek(0)
+        file = SimpleUploadedFile('test_file.df', pdf_file.read())
+        # Data for the form
         data_pdf = {'description': 'description pdf',
                     'amount': 1,
-                    'receipt_image': django_friendly_pdf_file}
-        form_png = ReceiptForm(data_png, instance=receipt_png)
-        form_pdf = ReceiptForm(data_pdf, instance=receipt_pdf)
+                    }
+        files = {'receipt_image': file}
+        form_pdf = ReceiptForm(data_pdf, files, instance=Receipt(application=self.application))
 
-        self.assertTrue(form_png.is_valid())
-        self.assertTrue(form_pdf.is_valid())
+        self.assertTrue(form_pdf.is_valid(), msg=form_pdf.errors)
+        form_pdf.save()
 
     def test_missing_image(self):
         """Verifies the form is not valid when the receipt_image field is blank."""
-        receipt = Receipt(
-            application=self.application,
-            description='description of file',
-            amount=1)
-        receipt.user = self.user
-        receipt.save()
         data = {'description': 'description of file',
-                'amount': 1}
-        form = ReceiptForm(data, instance=receipt)
+                'amount': 1,
+                }
+        form = ReceiptForm(data, {}, instance=Receipt(application=self.application))
 
-        self.assertFalse(form.is_valid())
+        self.assertIn('This field is required.', form.errors['receipt_image'])

--- a/pycon/finaid/tests/test_forms.py
+++ b/pycon/finaid/tests/test_forms.py
@@ -2,9 +2,12 @@ import datetime
 
 from django.contrib.auth.models import User
 from django.test import TestCase
+from django.core.files.uploadedfile import SimpleUploadedFile
 
-from ..models import FinancialAidApplication, FinancialAidMessage, PYTHON_EXPERIENCE_BEGINNER
-from pycon.finaid.forms import FinancialAidApplicationForm, ReviewerMessageForm
+from ..models import FinancialAidApplication, FinancialAidMessage,\
+    PYTHON_EXPERIENCE_BEGINNER, Receipt
+from pycon.finaid.forms import FinancialAidApplicationForm, ReviewerMessageForm,\
+    ReceiptForm
 
 
 today = datetime.date.today()
@@ -64,3 +67,67 @@ class FinancialAidTest(TestCase):
         message = form.save()
         message = FinancialAidMessage.objects.get(pk=message.pk)
         self.assertTrue(message.visible)
+
+
+class TestReceiptForm(TestCase):
+
+    def setUp(self):
+        super(TestReceiptForm, self).setUp()
+        self.user = User.objects.create_user("Foo")
+        self.application = FinancialAidApplication.objects.create(
+            user=self.user,
+            profession="Foo",
+            experience_level=PYTHON_EXPERIENCE_BEGINNER,
+            what_you_want="money",
+            use_of_python="fun",
+            presenting=1,
+        )
+        self.application.save()
+
+    def test_valid_receipt(self):
+        """Checks form is valid with SimpleUploadeFile extension pdf or png."""
+        simple_file_pdf = SimpleUploadedFile(
+            'test_file.pdf',
+            str('contents of the test file'))
+        simple_file_png = SimpleUploadedFile(
+            'test_file.png',
+            str('contents of the test file'))
+        receipt_pdf = Receipt(
+            application=self.application,
+            description='description',
+            amount=1,
+            receipt_image=simple_file_pdf)
+        receipt_png = Receipt(
+            application=self.application,
+            description='description',
+            amount=1,
+            receipt_image=simple_file_png)
+        receipt_pdf.user = self.user
+        receipt_png.user = self.user
+        receipt_pdf.save()
+        receipt_png.save()
+        data_pdf = {'description': 'description',
+                    'amount': 1,
+                    'receipt_image': simple_file_pdf}
+        data_png = {'description': 'description',
+                    'amount': 1,
+                    'receipt_image': simple_file_png}
+        form_pdf = ReceiptForm(data_pdf, instance=receipt_pdf)
+        form_png = ReceiptForm(data_png, instance=receipt_png)
+
+        self.assertTrue(form_pdf.is_valid())
+        self.assertTrue(form_png.is_valid())
+
+    def test_missing_image(self):
+        """Verifies the form is not valid when the receipt_image field is blank."""
+        receipt = Receipt(
+            application=self.application,
+            description='description',
+            amount=1)
+        receipt.user = self.user
+        receipt.save()
+        data = {'description': 'description',
+                'amount': 1}
+        form = ReceiptForm(data, instance=receipt)
+
+        self.assertFalse(form.is_valid())

--- a/pycon/finaid/tests/test_forms.py
+++ b/pycon/finaid/tests/test_forms.py
@@ -94,22 +94,22 @@ class TestReceiptForm(TestCase):
             str('contents of the test file'))
         receipt_pdf = Receipt(
             application=self.application,
-            description='description',
+            description='description_pdf',
             amount=1,
             receipt_image=simple_file_pdf)
         receipt_png = Receipt(
             application=self.application,
-            description='description',
+            description='description_png',
             amount=1,
             receipt_image=simple_file_png)
         receipt_pdf.user = self.user
         receipt_png.user = self.user
         receipt_pdf.save()
         receipt_png.save()
-        data_pdf = {'description': 'description',
+        data_pdf = {'description': 'description_pdf',
                     'amount': 1,
                     'receipt_image': simple_file_pdf}
-        data_png = {'description': 'description',
+        data_png = {'description': 'description_png',
                     'amount': 1,
                     'receipt_image': simple_file_png}
         form_pdf = ReceiptForm(data_pdf, instance=receipt_pdf)
@@ -118,15 +118,34 @@ class TestReceiptForm(TestCase):
         self.assertTrue(form_pdf.is_valid())
         self.assertTrue(form_png.is_valid())
 
+    def test_invalid_format(self):
+        """Invalid receipt image formats should cause the form to be invalid."""
+        simple_file_txt = SimpleUploadedFile(
+            'test_file.txt',
+            str('contents of the test file'))
+        receipt_txt = Receipt(
+            application=self.application,
+            description='description_txt',
+            amount=1,
+            receipt_image=simple_file_txt)
+        receipt_txt.user = self.user
+        receipt_txt.save()
+        data_txt = {'description': 'description_txt',
+                    'amount': 1,
+                    'receipt_image': simple_file_txt}
+        form_txt = ReceiptForm(data_txt, instance=receipt_txt)
+
+        self.assertFalse(form_txt.is_valid())
+
     def test_missing_image(self):
         """Verifies the form is not valid when the receipt_image field is blank."""
         receipt = Receipt(
             application=self.application,
-            description='description',
+            description='description of file',
             amount=1)
         receipt.user = self.user
         receipt.save()
-        data = {'description': 'description',
+        data = {'description': 'description of file',
                 'amount': 1}
         form = ReceiptForm(data, instance=receipt)
 

--- a/pycon/finaid/tests/test_forms.py
+++ b/pycon/finaid/tests/test_forms.py
@@ -113,7 +113,7 @@ class TestReceiptForm(TestCase):
         # Use PIL Image to create new png and pdf files
         Image.new('RGB', size=(50, 50), color=(256, 0, 0)).save(pdf_file, 'pdf')
         pdf_file.seek(0)
-        file = SimpleUploadedFile('test_file.df', pdf_file.read())
+        file = SimpleUploadedFile('test_file.pdf', pdf_file.read())
         # Data for the form
         data_pdf = {'description': 'description pdf',
                     'amount': 1,

--- a/pycon/finaid/views.py
+++ b/pycon/finaid/views.py
@@ -608,7 +608,6 @@ def receipt_upload(request):
         form = ReceiptForm(request.POST, request.FILES)
 
         if form.is_valid():
-            form.instance.user = request.user
             form.instance.application = request.user.financial_aid
             form.save()
 


### PR DESCRIPTION
Fixes #549.
Another thought is whether receipt_image should be renamed to something like receipt_document, since it no longer has to be an image