### PR TITLE
551 Fix error submitting reviews

### DIFF
--- a/symposion/reviews/models.py
+++ b/symposion/reviews/models.py
@@ -18,6 +18,14 @@ PROPOSAL_SCORE_EXPRESSION = \
 
 
 class Votes(object):
+    """
+    *** NOTE ***
+
+    The MINUS_ZERO and MINUS_ONE values here are using fancy Unicode
+    minus signs instead of ASCII minus sign/dashes.  This works fine so
+    long as everything using these does it consistently; just be careful
+    to use VOTES.MINUS_ZERO instead of writing out "-0" anywhere.
+    """
     PLUS_ONE = "+1"
     PLUS_ZERO = "+0"
     MINUS_ZERO = u"−0"

--- a/symposion/reviews/models.py
+++ b/symposion/reviews/models.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from decimal import Decimal
 
 from django.db import models
-from django.db.models import Q
+from django.db.models import Q, F
 from django.db.models.signals import post_save
 
 from django.contrib.auth.models import User
@@ -12,14 +12,9 @@ from symposion.proposals.models import ProposalBase
 from symposion.schedule.models import Presentation
 
 
-class ProposalScoreExpression(object):
-
-    def as_sql(self, qn, connection=None):
-        sql = "((3 * plus_one + plus_zero) - (minus_zero + 3 * minus_one))"
-        return sql, []
-
-    def prepare_database_save(self, unused):
-        return self
+# How we compute proposal scores: 3*(+1's) + (+0's) - (-0's) - 3*(-1's)
+PROPOSAL_SCORE_EXPRESSION = \
+    3 * F('plus_one') + F('plus_zero') - F('minus_zero') - 3 * F('minus_one')
 
 
 class Votes(object):
@@ -115,6 +110,9 @@ class Review(models.Model):
                     submitted_at = self.submitted_at,
                 )
             )
+            # Ensure there's a result object
+            ProposalResult.objects.get_or_create(proposal=self.proposal)
+            # Update the score
             if not created:
                 LatestVote.objects.filter(pk=vote.pk).update(vote=self.vote)
                 self.proposal.result.update_vote(self.vote, previous=vote.vote)
@@ -249,7 +247,7 @@ class ProposalResult(models.Model):
                 vote = VOTES.MINUS_ONE
             ).count()
             result.save()
-            cls._default_manager.filter(pk=result.pk).update(score=ProposalScoreExpression())
+            cls._default_manager.filter(pk=result.pk).update(score=PROPOSAL_SCORE_EXPRESSION)
 
     def update_vote(self, vote, previous=None, removal=False):
         mapping = {
@@ -278,7 +276,7 @@ class ProposalResult(models.Model):
             self.comment_count = models.F("comment_count") + 1
         self.save()
         model = self.__class__
-        model._default_manager.filter(pk=self.pk).update(score=ProposalScoreExpression())
+        model._default_manager.filter(pk=self.pk).update(score=PROPOSAL_SCORE_EXPRESSION)
 
 
 class Comment(models.Model):

--- a/symposion/reviews/tests.py
+++ b/symposion/reviews/tests.py
@@ -281,7 +281,7 @@ class SubmitReviewTest(ReviewTestMixin, TestCase):
         user2.user_permissions.add(perm)
 
         # User submits first vote: +1
-        talk = self.submit_review(talk, self.user, "+1")
+        talk = self.submit_review(talk, self.user, Votes.PLUS_ONE)
         # One +1 vote gives a score of 3
         self.assertEqual(3, talk.result.score)
 
@@ -293,6 +293,6 @@ class SubmitReviewTest(ReviewTestMixin, TestCase):
 
         # Now, add a vote from a different user, which should be counted
         # separately and adjust the score
-        talk = self.submit_review(talk, user2, "+1")
+        talk = self.submit_review(talk, user2, Votes.PLUS_ONE)
         # Adding a new +1 vote adds 3 to the previous score
         self.assertEqual(2, talk.result.score)

--- a/symposion/reviews/tests.py
+++ b/symposion/reviews/tests.py
@@ -10,7 +10,8 @@ from pycon.tests.factories import PyConTalkProposalFactory, PyConTutorialProposa
     ProposalResultFactory
 from symposion.proposals.models import ProposalBase, ProposalKind
 from symposion.proposals.tests.factories import init_kinds
-from symposion.reviews.models import Review, ReviewAssignment
+from symposion.reviews.models import Review, ReviewAssignment, Votes
+from symposion.reviews.views import is_voting_period_active
 
 
 class login(object):
@@ -244,3 +245,54 @@ class ReviewPageTest(ReviewTestMixin, TestCase):
         self.assertNotContains(rsp, "My talk category")
         self.assertContains(rsp, tutorial.title)
         self.assertContains(rsp, "My tutorial category")
+
+
+class SubmitReviewTest(ReviewTestMixin, TestCase):
+    fixtures = [
+        'conference.json',
+        'proposal_base.json',
+    ]
+
+    def submit_review(self, proposal, user, vote):
+        # Submit a vote and return the updated proposal object
+        assert is_voting_period_active(proposal)
+        self.login(username=user.username)
+        url = reverse('review_detail', kwargs={'pk': proposal.pk})
+        data = dict(
+            vote_submit="yep",
+            vote=vote,
+            comment="deep thoughts",
+        )
+        rsp = self.client.post(url, data)
+        self.assertRedirects(rsp, url)
+        return type(proposal).objects.get(pk=proposal.pk)
+
+    def test_submit_review(self):
+        # Reviewers can submit multiple reviews. Only their most recent vote counts.
+        talk = PyConTalkProposalFactory(title="talk", description="talk",
+                                        category__name="My talk category")
+        self.user = self.create_user()
+        perm, __ = Permission.objects.get_or_create(
+            codename="can_review_talks",
+            content_type=ContentType.objects.get_for_model(Review),
+        )
+        self.user.user_permissions.add(perm)
+        user2 = self.create_user(username="user2")
+        user2.user_permissions.add(perm)
+
+        # User submits first vote: +1
+        talk = self.submit_review(talk, self.user, "+1")
+        # One +1 vote gives a score of 3
+        self.assertEqual(3, talk.result.score)
+
+        # Let's try adding another vote - because it's from the same
+        # user, it should supersede their previous vote in the score.
+        talk = self.submit_review(talk, self.user, Votes.MINUS_ZERO)
+        # A -0 vote is a score of -1
+        self.assertEqual(-1, talk.result.score)
+
+        # Now, add a vote from a different user, which should be counted
+        # separately and adjust the score
+        talk = self.submit_review(talk, user2, "+1")
+        # Adding a new +1 vote adds 3 to the previous score
+        self.assertEqual(2, talk.result.score)

--- a/symposion/reviews/views.py
+++ b/symposion/reviews/views.py
@@ -246,9 +246,10 @@ def is_review_period_active(proposal):
 
 
 def is_voting_period_active(proposal):
-    if proposal.result is None or proposal.result.group is None:
+    result = ProposalResult.objects.filter(proposal=proposal).first()
+    if result is None or result.group is None:
         return True
-    group = proposal.result.group
+    group = result.group
     return group.vote_start <= datetime.datetime.now() <= group.vote_end
 
 


### PR DESCRIPTION
Added test to recreate problem.

I think this was something that broke when Django was
upgraded, but without a unit test, we weren't aware of
it.

Change from passing a class instance to .update() to
using the (documented) F function to do the same thing
that seemed to be intended.

Also work around Django's annoying behavior of raising
an exception when a reverse relation has no object.

Fixes #551