### PR TITLE
front end fixes to nav, sponsor list, and venue page

### DIFF
--- a/pycon/static/less/site.less
+++ b/pycon/static/less/site.less
@@ -773,11 +773,10 @@ header.main {
           border-bottom: 2px solid transparent;
           &:hover {
             color: @maroon;
-            border-bottom: 2px solid @maroon;
             .transition(0.25s);
           }
           &.active {
-            border-bottom: 2px solid @maroon;
+            border-bottom-color: @maroon;
           }
           &:focus {
             .caret {
@@ -873,12 +872,16 @@ header.main {
               a {
                 color: @maroon;
                 background-image: none;
+                &:hover {
+                  border-bottom-color: transparent;
+                }
               }
             }
             a {
               margin: 0;
               color: @grayDark;
               padding: 1em 0;
+              border-bottom: 2px solid transparent;
               @media (max-width: @breakDesktop) {
                 padding-left: 0 !important;
               }
@@ -887,6 +890,7 @@ header.main {
               &:focus,
               &.active {
                 background-image: none;
+                border-bottom: 2px solid @maroon;
               }
 
               &:hover,
@@ -1267,6 +1271,7 @@ body.home {
           font-size: @baseFontSize * 2;
           text-decoration: none;
           border-bottom: none;
+          margin-bottom: 0.25em;
         }
       }
     }
@@ -1666,7 +1671,9 @@ body.venue {
 
 /* CMS Pages
 ==================== */
-body.cms-page {
+
+body.cms-page,
+body.venue {
   h1, h2, h3, h4, h5, h6 {
     text-transform: capitalize;
   }
@@ -1677,6 +1684,9 @@ body.cms-page {
     padding-top: .8em;
     line-height: 1.4em;
   }
+}
+
+body.cms-page {
   .edit-btn {
     .btn;
     .btn-primary;

--- a/pycon/templates/sponsorship/list.html
+++ b/pycon/templates/sponsorship/list.html
@@ -3,6 +3,7 @@
 {% load cache %}
 {% load sponsorship_tags %}
 {% load thumbnail %}
+{% load sitetree %}
 {% load i18n %}
 
 {% block head_title %}{% trans "About PyCon Sponsors" %}{% endblock %}
@@ -16,6 +17,8 @@
         <i class="icon icon-arrow-right"></i>
     </a>
 {% endblock %}
+
+{% block breadcrumbs %}{% sitetree_breadcrumbs from "main" %}{% endblock %}
 
 {% block page_content %}
     <div class="container">


### PR DESCRIPTION
added breadcrumbs the sponsor page, fixed double underline on active nav item, and changed H1 on venue pages to title case.