### PR TITLE
make flickity wait until images are loaded

### DIFF
--- a/pycon/templates/homepage.html
+++ b/pycon/templates/homepage.html
@@ -116,7 +116,7 @@
               <h2 class="scroll-title">{% trans "A look at past PyCons" %}</h2>
               <!-- Past PyCon Carousel -->
               <div class="js-flickity main-gallery"
-              data-flickity-options='{ "contain": true, "wrapAround": true }'>
+              data-flickity-options='{ "contain": true, "wrapAround": true, "imagesLoaded": true }'>
                 <img src="{{ STATIC_URL }}img/landing-slideshow/Small/2015-escalator-sm.jpg" alt="interior of Palais des congrès de Montréal" />
                 <img src="{{ STATIC_URL }}img/landing-slideshow/Small/2014-speaker-sm.jpg" alt="speaker at PyCon 2014" />
                 <img src="{{ STATIC_URL }}img/landing-slideshow/Small/2014-conference-hall-sm.jpg" alt="2014 conference hall" />


### PR DESCRIPTION
A possible fix to the scrollbar issue on the homepage; not sure, though, since unable to recreate issue in local environment