### PR TITLE
make overflow:visible in container with images

### DIFF
--- a/pycon/static/less/site.less
+++ b/pycon/static/less/site.less
@@ -1278,7 +1278,7 @@ body.home {
   }
 
   .past-pycon-announcements {
-    overflow: auto;
+    overflow: visible;
     .half {
       @media (max-width:@breakDesktop) {
         width: 100%;
@@ -1298,7 +1298,7 @@ body.home {
     }
 
     .pycon-past {
-      overflow: auto;
+      overflow: visible;
     }
 
     .pycon-announcements {


### PR DESCRIPTION
Seems to solve the issue with the scrollbar and the gallery dots beneath the images