### PR TITLE
Fix 500 viewing proposal once presentation exists

### DIFF
--- a/symposion/proposals/models.py
+++ b/symposion/proposals/models.py
@@ -124,6 +124,10 @@ class ProposalBase(models.Model):
         return self.title
 
     def can_edit(self):
+        """
+        Return True if this proposal is editable - meaning no presentation exists yet.
+        """
+        # Putting this import at the top would result in a circular import
         from symposion.schedule.models import Presentation
         return not Presentation.objects.filter(proposal_base=self).exists()
 

--- a/symposion/proposals/models.py
+++ b/symposion/proposals/models.py
@@ -124,10 +124,8 @@ class ProposalBase(models.Model):
         return self.title
 
     def can_edit(self):
-        if hasattr(self, "presentation") and self.presentation_id:
-            return False
-        else:
-            return True
+        from symposion.schedule.models import Presentation
+        return not Presentation.objects.filter(proposal_base=self).exists()
 
     def cache_tags(self):
         self.cached_tags = self.get_tags_display()

--- a/symposion/proposals/tests/factories.py
+++ b/symposion/proposals/tests/factories.py
@@ -24,6 +24,7 @@ class ProposalBaseFactory(factory.DjangoModelFactory):
     class Meta:
         model = ProposalBase
 
+    kind = factory.SubFactory(ProposalKindFactory)
     speaker = factory.SubFactory(SpeakerFactory)
 
 

--- a/symposion/proposals/tests/test_proposals.py
+++ b/symposion/proposals/tests/test_proposals.py
@@ -1,0 +1,13 @@
+from django.test import TestCase
+
+from symposion.proposals.tests.factories import ProposalBaseFactory
+from symposion.schedule.tests.factories import PresentationFactory
+
+
+class ProposalsTest(TestCase):
+    def test_can_edit(self):
+        # If a presentation has been created, speaker can no longer edit their proposal
+        prop = ProposalBaseFactory()
+        self.assertTrue(prop.can_edit())
+        PresentationFactory(proposal_base=prop)
+        self.assertFalse(prop.can_edit())


### PR DESCRIPTION
The way we were checking if a proposal had a presentation
was raising 500s:

  File "/srv/pycon/pycon/symposion/proposals/models.py", line 127, in
can_edit
    if hasattr(self, "presentation") and self.presentation_id:
    AttributeError: 'PyConTalkProposal' object has no attribute
    'presentation_id'

Since 'presentation' is a related name and not a foreign key to
the presentation record, there's no 'presentation_id' field.

Change to query the Presentation model directly to see if
there's one that points at this proposal.

Added a test first, verified that it failed, then made this fix
and now the test passes.