### PR TITLE
Fix user selection for speaker add

### DIFF
--- a/symposion/speakers/admin.py
+++ b/symposion/speakers/admin.py
@@ -7,6 +7,7 @@ from symposion.speakers.models import Speaker
 
 class SpeakerAdmin(MarkEditAdmin):
     list_display = ["name", "email", "created", "twitter_username"]
+    raw_id_fields = ["user"]
     search_fields = ["name", "twitter_username"]
 
     class MarkEdit:


### PR DESCRIPTION
When adding a speaker in the admin, the staff person had to
pick a user from a huge dropdown with all the users, unsorted.

Change 'user' to a raw id field, meaning to pick a user, the staff member clicks a magnifying glass icon next to the field and gets a popup listing all the users in an admin list page with sortable columns and search.