### PR TITLE
Adds room information schedule detail

### DIFF
--- a/pycon/templates/schedule/presentation_detail.html
+++ b/pycon/templates/schedule/presentation_detail.html
@@ -28,6 +28,7 @@
         <h4>
             {{ presentation.slot.day.date|date:"l" }}
             {{ presentation.slot.start}}&ndash;{{ presentation.slot.end }}
+            ({{ presentation.slot.rooms|join:", " }})
         </h4>
         {% if proposal.domain_level %}
             {% if request.user.speaker_profile in speakers or request.user.is_staff %}


### PR DESCRIPTION
**Problem**

I was searching for the room of talk into the schedule details, but my only to find it was to press the back button and to get back to the full talk schedule

**Goal**

This PR is simply adding the room informations into the talk details, when available

**Review**

@daaray @brandon-rhodes 
