### PR TITLE
Implement bump_unsubmitted_proposals management command

### DIFF
--- a/pycon/management/commands/bump_unsubmitted_proposals.py
+++ b/pycon/management/commands/bump_unsubmitted_proposals.py
@@ -1,0 +1,40 @@
+from collections import defaultdict
+
+from django.contrib.sites.models import Site
+from django.core.management.base import BaseCommand
+from django.core.urlresolvers import reverse
+from symposion.proposals.kinds import get_kind_slugs, get_proposal_model
+from symposion.utils.mail import send_email
+
+SLUGS = get_kind_slugs()
+DOMAIN = Site.objects.get_current().domain
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument('--kind', action='store', dest='kind', required=True,
+                            help='Proposal Kind to bump: {}'.format(', '.join(SLUGS)))
+
+    def handle(self, *args, **options):
+        if options['kind'] not in SLUGS:
+            print('ERROR: Unknown Proposal Kind: {}\n       Must be one of: {}'.format(options['kind'], ', '.join(SLUGS)))
+            return False
+
+        to_bump = defaultdict(list)
+
+        unsubmitted = get_proposal_model(options['kind']).objects.filter(submitted=False)
+        for unsub in unsubmitted:
+            path = reverse('proposal_detail', args=[unsub.id])
+            url = 'https://{domain}{path}'.format(domain=DOMAIN, path=path)
+            to_bump[unsub.speaker.email].append(unsub)
+
+        for email, proposals in to_bump.items():
+            send_email(
+                to=[email],
+                kind='proposal_bump',
+                context={
+                    'proposal_kind': options['kind'],
+                    'user': proposals[0].speaker.user,
+                    'proposals': proposals,
+                },
+            )

--- a/symposion/templates/emails/proposal_bump/message.html
+++ b/symposion/templates/emails/proposal_bump/message.html
@@ -1,0 +1,17 @@
+{% load account_tags %}
+{{ user.get_full_name|safe }},
+<p> 
+The deadline to submit proposals for PyCon 2018 {{ proposal_kind }}s is quickly approaching! For more information on the timelines see: <a href="https://{{current_site}}/2018/speaking/{{ proposal_kind }}s">https://{{current_site}}/2018/speaking/{{ proposal_kind }}s</a>.
+</p>
+<p>
+We noticed that you have {{ proposals|length }} unsubmitted {{ proposal_kind }} proposal{% if proposals|length > 1 %}s{% endif %}: 
+<ul>
+{% for proposal in proposals %}
+  {% url 'proposal_detail' proposal.id as detail_url %}<li>{{ proposal.title }}: <a href="https://{{ current_site }}{{ detail_url }}">https://{{current_site}}{{ detail_url }}</a></li>
+{% endfor %}
+</ul>
+</p>
+<p>
+When you're ready, you can press submit for your proposals at <a href="https://{{ current_site }}/2018/dashboard/">https://{{current_site}}/2018/dashboard/</a>
+</p>
+- The PyCon Robot

--- a/symposion/templates/emails/proposal_bump/subject.txt
+++ b/symposion/templates/emails/proposal_bump/subject.txt
@@ -1,0 +1,1 @@
+Reminder! Unsubmitted {{ proposal_kind|title }} Proposal{% if proposals|length > 1 %}s{% endif %}


### PR DESCRIPTION
This can be used to remind folks who have started, but not completed and submitted their proposals!

It's setup so we can use it to bump any proposal type (`talk`, `tutorial`, `poster`, `edusummit`), and we'll run these manually.

cc: @rdodev @jasonamyers @bbengfort @jessingrass

Sample:
<img width="1095" alt="screen shot 2017-11-12 at 10 25 53 am" src="https://user-images.githubusercontent.com/1200832/32700506-5319dad2-c794-11e7-8f8e-1cb2866ce8d7.png">