### PR TITLE
Job fair participation flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test flake8 docs up down reset-volume reset rebuild
+.PHONY: all test flake8 docs up down reset-volume reset rebuild migrate makemigrations
 
 MAKEFLAGS = silent
 
@@ -25,6 +25,12 @@ up:
 	@docker-compose run web python manage.py migrate
 	@docker-compose run web python manage.py loaddata fixtures/*.json
 	@open http://localhost:8000
+
+makemigrations:
+	@docker-compose run web python manage.py makemigrations
+
+migrate:
+	@docker-compose run web python manage.py migrate
 
 down:
 	@docker-compose down

--- a/fixtures/sitetree_menu.json
+++ b/fixtures/sitetree_menu.json
@@ -2,7 +2,7 @@
     {
         "fields": {
             "alias": "main",
-            "title": "PyCon US 2014"
+            "title": "PyCon US 2018"
         },
         "model": "sitetree.tree",
         "pk": 1
@@ -32,7 +32,7 @@
             "sort_order": 1,
             "title": "About",
             "tree": 1,
-            "url": "/2014/about/what-is-pycon/",
+            "url": "/2018/about/what-is-pycon/",
             "urlaspattern": false
         },
         "model": "sitetree.treeitem",
@@ -78,7 +78,7 @@
             "sort_order": 3,
             "title": "Sponsors",
             "tree": 1,
-            "url": "/2014/sponsors/",
+            "url": "/2018/sponsors/",
             "urlaspattern": false
         },
         "model": "sitetree.treeitem",
@@ -147,7 +147,7 @@
             "sort_order": 8,
             "title": "PyCon Mobile Guide",
             "tree": 1,
-            "url": "http://guidebook.com/g/pycon2014/",
+            "url": "http://guidebook.com/g/pycon2018/",
             "urlaspattern": false
         },
         "model": "sitetree.treeitem",
@@ -446,7 +446,7 @@
             "sort_order": 2,
             "title": "Speaking",
             "tree": 1,
-            "url": "/2014/speaking/speakatpycon/",
+            "url": "/2018/speaking/speakatpycon/",
             "urlaspattern": false
         },
         "model": "sitetree.treeitem",
@@ -920,7 +920,7 @@
             "access_restricted": false,
             "alias": null,
             "description": "",
-            "hidden": true,
+            "hidden": false,
             "hint": "",
             "inbreadcrumbs": true,
             "inmenu": true,
@@ -929,7 +929,7 @@
             "sort_order": 12,
             "title": "Jobs Fair",
             "tree": 1,
-            "url": "/2014/sponsors/jobs/",
+            "url": "/2018/sponsors/jobs/",
             "urlaspattern": false
         },
         "model": "sitetree.treeitem",
@@ -1019,7 +1019,7 @@
             "insitetree": true,
             "parent": 45,
             "sort_order": 47,
-            "title": "Register for PyCon 2014",
+            "title": "Register for PyCon 2018",
             "tree": 1,
             "url": "registration_start",
             "urlaspattern": true
@@ -1274,7 +1274,7 @@
             "sort_order": 26,
             "title": "Conference Talk List",
             "tree": 1,
-            "url": "/2014/schedule/talks/list/",
+            "url": "/2018/schedule/talks/list/",
             "urlaspattern": false
         },
         "model": "sitetree.treeitem",
@@ -1297,7 +1297,7 @@
             "sort_order": 41,
             "title": "Tutorial List",
             "tree": 1,
-            "url": "/2014/schedule/tutorials/list/",
+            "url": "/2018/schedule/tutorials/list/",
             "urlaspattern": false
         },
         "model": "sitetree.treeitem",
@@ -1320,7 +1320,7 @@
             "sort_order": 43,
             "title": "Tutorial Schedule",
             "tree": 1,
-            "url": "/2014/schedule/tutorials/",
+            "url": "/2018/schedule/tutorials/",
             "urlaspattern": false
         },
         "model": "sitetree.treeitem",
@@ -1412,7 +1412,7 @@
             "sort_order": 27,
             "title": "Conference Talk Schedule",
             "tree": 1,
-            "url": "/2014/schedule/talks/",
+            "url": "/2018/schedule/talks/",
             "urlaspattern": false
         },
         "model": "sitetree.treeitem",
@@ -1435,7 +1435,7 @@
             "sort_order": 44,
             "title": "Sponsor Workshops",
             "tree": 1,
-            "url": "/2014/schedule/sponsor-tutorials/",
+            "url": "/2018/schedule/sponsor-tutorials/",
             "urlaspattern": false
         },
         "model": "sitetree.treeitem",
@@ -1481,7 +1481,7 @@
             "sort_order": 58,
             "title": "Poster Session",
             "tree": 1,
-            "url": "/2014/schedule/posters/list/",
+            "url": "/2018/schedule/posters/list/",
             "urlaspattern": false
         },
         "model": "sitetree.treeitem",
@@ -1518,7 +1518,7 @@
             "access_restricted": false,
             "alias": null,
             "description": "",
-            "hidden": true,
+            "hidden": false,
             "hint": "",
             "inbreadcrumbs": true,
             "inmenu": true,
@@ -1527,7 +1527,7 @@
             "sort_order": 60,
             "title": "Jobs Fair",
             "tree": 1,
-            "url": "/2014/sponsors/jobs/",
+            "url": "/2018/sponsors/jobs/",
             "urlaspattern": false
         },
         "model": "sitetree.treeitem",
@@ -1550,7 +1550,7 @@
             "sort_order": 61,
             "title": "Charity Auction",
             "tree": 1,
-            "url": "/2014/sponsors/charityauction/",
+            "url": "/2018/sponsors/charityauction/",
             "urlaspattern": false
         },
         "model": "sitetree.treeitem",

--- a/fixtures/sponsorship_benefits.json
+++ b/fixtures/sponsorship_benefits.json
@@ -29,7 +29,7 @@
     {
         "fields": {
             "type": "text",
-            "name": "Listing on Jobs Fair",
+            "name": "Job Listing(s)",
             "description": ""
         },
         "model": "sponsorship.benefit",

--- a/pycon/sponsorship/admin.py
+++ b/pycon/sponsorship/admin.py
@@ -45,8 +45,9 @@ class SponsorAdmin(admin.ModelAdmin):
             "fields": ["wants_table", "wants_booth", "small_entity_discount"],
         }),
         ("Sponsor Data", {
-            "fields": ["booth_number", "job_fair_table_number",
-                       "registration_promo_codes", "expo_promo_codes"],
+            "fields": ["booth_number", "job_fair_participant",
+                       "job_fair_table_number", "registration_promo_codes",
+                       "expo_promo_codes"],
         }),
         ("Contact Information", {
             "fields": ["contact_name", "contact_emails", "contact_phone",

--- a/pycon/sponsorship/migrations/0018_sponsor_job_fair_participant.py
+++ b/pycon/sponsorship/migrations/0018_sponsor_job_fair_participant.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sponsorship', '0017_sponsorship_form_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='sponsor',
+            name='job_fair_participant',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/pycon/sponsorship/models.py
+++ b/pycon/sponsorship/models.py
@@ -9,6 +9,7 @@ from django.db.models import SET_NULL
 from django.db.models.signals import post_init, post_save, pre_save
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
+from django.template import Context, Template
 
 from django.contrib.auth.models import User
 from multi_email_field.fields import MultiEmailField
@@ -173,7 +174,11 @@ class Sponsor(models.Model):
         %%REGISTRATION_PROMO_CODES%% --> Registration promo codes, or empty string
         %%EXPO_PROMO_CODES%% --> Expo Hall only promo codes, or empty string
         %%BOOTH_NUMBER%% --> Booth number, or empty string if not set
-        %%JOB_FAIR_TABLE_NUMBER%%" --> Job fair tabl number, or empty string if not set
+        %%JOB_FAIR_TABLE_NUMBER%%" --> Job fair table number, or empty string if not set
+
+        Flags:
+          JOB_FAIR_PARTICIPANT: Use with {% if JOB_FAIR_PARTICIPANT %} block to
+                                include some content for Job Fair Participants
         """
         text = text.replace("%%NAME%%", self.name)
         text = text.replace("%%REGISTRATION_PROMO_CODES%%",
@@ -187,6 +192,11 @@ class Sponsor(models.Model):
         text = text.replace("%%BOOTH_NUMBER%%", booth)
         table = str(self.job_fair_table_number) if self.job_fair_table_number is not None else ""
         text = text.replace("%%JOB_FAIR_TABLE_NUMBER%%", table)
+        email_template = Template(text)
+        email_context = Context({
+            'JOB_FAIR_PARTICIPANT': self.job_fair_participant,
+        })
+        text = email_template.render(email_context)
         return text
 
     @cached_property

--- a/pycon/sponsorship/models.py
+++ b/pycon/sponsorship/models.py
@@ -121,6 +121,7 @@ class Sponsor(models.Model):
     registration_promo_codes = models.CharField(max_length=200, blank=True, default='')
     expo_promo_codes = models.CharField(max_length=200, blank=True, default='')
     booth_number = models.IntegerField(blank=True, null=True, default=None)
+    job_fair_participant = models.BooleanField(default=False)
     job_fair_table_number = models.IntegerField(blank=True, null=True, default=None)
 
     web_description = models.TextField(

--- a/pycon/sponsorship/templatetags/sponsorship_tags.py
+++ b/pycon/sponsorship/templatetags/sponsorship_tags.py
@@ -47,6 +47,21 @@ def job_sponsors():
     return grouped_sponsors
 
 
+@register.assignment_tag
+def job_fair_participants():
+    """
+    Returns active sponsors and table number, grouped by level name, who will
+    be participating in the Job Fair.
+    """
+    conference = current_conference()
+    sponsors = Sponsor.objects.filter(level__conference=conference, active=True)
+    sponsors = sponsors.order_by('level__order', 'added')
+    sponsors = [s for s in sponsors if s.job_fair_participant]
+    grouped_sponsors = groupby(sponsors, attrgetter('level.name'))
+    grouped_sponsors = [(name, list(sponsors)) for name, sponsors in grouped_sponsors]
+    return grouped_sponsors
+
+
 @register.filter
 def mod(a, b):
     return int(a) % int(b)

--- a/pycon/static/css/simple-grid.css
+++ b/pycon/static/css/simple-grid.css
@@ -1,0 +1,191 @@
+/**
+*** SIMPLE GRID
+*** (C) ZACH COLE 2016
+**/
+
+/* POSITIONING */
+
+.left {
+  text-align: left;
+}
+
+.right {
+  text-align: right;
+}
+
+.center {
+  text-align: center;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.justify {
+  text-align: justify;
+}
+
+/* ==== GRID SYSTEM ==== */
+
+.container {
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.row {
+  position: relative;
+  width: 100%;
+}
+
+.row [class^="col"] {
+  float: left;
+  margin: 0.5rem 2%;
+  min-height: 0.125rem;
+}
+
+.col-1,
+.col-2,
+.col-3,
+.col-4,
+.col-5,
+.col-6,
+.col-7,
+.col-8,
+.col-9,
+.col-10,
+.col-11,
+.col-12 {
+  width: 96%;
+}
+
+.col-1-sm {
+  width: 4.33%;
+}
+
+.col-2-sm {
+  width: 12.66%;
+}
+
+.col-3-sm {
+  width: 21%;
+}
+
+.col-4-sm {
+  width: 29.33%;
+}
+
+.col-5-sm {
+  width: 37.66%;
+}
+
+.col-6-sm {
+  width: 46%;
+}
+
+.col-7-sm {
+  width: 54.33%;
+}
+
+.col-8-sm {
+  width: 62.66%;
+}
+
+.col-9-sm {
+  width: 71%;
+}
+
+.col-10-sm {
+  width: 79.33%;
+}
+
+.col-11-sm {
+  width: 87.66%;
+}
+
+.col-12-sm {
+  width: 96%;
+}
+
+.row::after {
+	content: "";
+	display: table;
+	clear: both;
+}
+
+.hidden-sm {
+  display: none;
+}
+
+.hidden-lg {
+  display: block;
+}
+
+@media only screen and (min-width: 33.75em) {  /* 540px */
+  .container {
+    width: 90%;
+  }
+}
+
+@media only screen and (min-width: 45em) {  /* 720px */
+  .col-1 {
+    width: 4.33%;
+  }
+
+  .col-2 {
+    width: 12.66%;
+  }
+
+  .col-3 {
+    width: 21%;
+  }
+
+  .col-4 {
+    width: 29.33%;
+  }
+
+  .col-5 {
+    width: 37.66%;
+  }
+
+  .col-6 {
+    width: 46%;
+  }
+
+  .col-7 {
+    width: 54.33%;
+  }
+
+  .col-8 {
+    width: 62.66%;
+  }
+
+  .col-9 {
+    width: 71%;
+  }
+
+  .col-10 {
+    width: 79.33%;
+  }
+
+  .col-11 {
+    width: 87.66%;
+  }
+
+  .col-12 {
+    width: 96%;
+  }
+
+  .hidden-sm {
+    display: block;
+  }
+
+  .hidden-lg {
+    display: none;
+  }
+}
+
+@media only screen and (min-width: 60em) { /* 960px */
+  .container {
+    width: 100%;
+    max-width: 60rem;
+  }
+}

--- a/pycon/static/css/slight.css
+++ b/pycon/static/css/slight.css
@@ -780,7 +780,7 @@ a {
   margin: 0 auto;
   color: #012A29;
   box-sizing: border-box;
-  max-width: 1024px;
+  max-width: 900px;
   padding: 0 10px;
   width: 100%;
 }

--- a/pycon/static/css/slight.css
+++ b/pycon/static/css/slight.css
@@ -780,7 +780,7 @@ a {
   margin: 0 auto;
   color: #012A29;
   box-sizing: border-box;
-  max-width: 900px;
+  max-width: 1024px;
   padding: 0 10px;
   width: 100%;
 }
@@ -1878,4 +1878,9 @@ body.account .page-content form {
   top: 15px;
   right: 15px;
   border-radius: 5px;
+}
+
+/* Jobs Page */
+
+#jobfairparticpants {
 }

--- a/pycon/templates/site_base.html
+++ b/pycon/templates/site_base.html
@@ -21,6 +21,7 @@
     <link rel="stylesheet" type="text/css" media="all" href="{% static "css/slight.css"%}"/>
     {% include "markedit/includes/markedit-css.html" %}
     {% block extra_style %}{% endblock %}
+    <link rel="stylesheet" type="text/css" media="all" href="{% static "css/simple-grid.css" %}"/>
 {% endblock %}
 
 {% block extra_head_base %}

--- a/pycon/templates/sponsorship/email.html
+++ b/pycon/templates/sponsorship/email.html
@@ -29,6 +29,7 @@
           <li>%%JOB_FAIR_TABLE_NUMBER%% will be replaced by the Job Fair Table Number.</li>
           <li>%%REGISTRATION_PROMO_CODES%% will be replaced by the Registration Promo Codes.</li>
           <li>%%EXPO_PROMO_CODES%% will be replaced by the Expo Hall Only Promo Codes.</li>
+          <li>JOB_FAIR_PARTICIPANT: Use with {% verbatim %}{% if JOB_FAIR_PARTICIPANT %}{% endverbatim %} block to include some content for Job Fair Participants</li>
         </ul>
 
        <form method="POST" action="{% url 'sponsor_email' pks %}" class="form-horizontal">

--- a/pycon/templates/sponsorship/jobs.html
+++ b/pycon/templates/sponsorship/jobs.html
@@ -33,6 +33,23 @@
     <blockquote class="callout">
       {% box "sponsor_jobs" %}
     </blockquote>
+    {% job_fair_participants as grouped_sponsors %}
+    <div class="jobfairparticpants">
+         <table>
+           <tr>
+             <th><b>Sponsor Name</b></th>
+             <th><b>Table Number</b></th>
+           </tr>
+         {% for level_name, sponsors in grouped_sponsors %}
+           {% for sponsor in sponsors %}
+           <tr>
+             <td><a href="{{ sponsor.external_url }}">{{ sponsor.name }}</a></td>
+             <td>{{ sponsor.job_fair_table_number }}</td>
+           </tr>
+           {% endfor %}
+         {% endfor %}
+         </table>
+    </div>
     {% job_sponsors as grouped_sponsors %}
     <div class="joblistings">
             {% for level_name, sponsors in grouped_sponsors %}

--- a/pycon/templates/sponsorship/jobs.html
+++ b/pycon/templates/sponsorship/jobs.html
@@ -30,42 +30,68 @@
 {% endblock %}
 
 {% block page_content %}
-    <blockquote class="callout">
-      {% box "sponsor_jobs" %}
-    </blockquote>
-    {% job_fair_participants as grouped_sponsors %}
-    <div class="jobfairparticpants">
-         <table>
-           <tr>
-             <th><b>Sponsor Name</b></th>
-             <th><b>Table Number</b></th>
-           </tr>
-         {% for level_name, sponsors in grouped_sponsors %}
-           {% for sponsor in sponsors %}
-           <tr>
-             <td><a href="{{ sponsor.external_url }}">{{ sponsor.name }}</a></td>
-             <td>{{ sponsor.job_fair_table_number }}</td>
-           </tr>
-           {% endfor %}
-         {% endfor %}
-         </table>
-    </div>
-    {% job_sponsors as grouped_sponsors %}
-    <div class="joblistings">
+    <div class="container">
+        <div class="row">
+          <blockquote class="callout">
+            {% box "sponsor_jobs" %}
+          </blockquote>
+        </div>
+        <div class="row hidden-lg" id="jobs-nav">
+          <div class="container">
+            <div class="row center">
+                <h4><a href="#job-fair-tables">Jump To Job Fair Directory</a></h4>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-8">
+            <div class="container center">
+              <h1 id="job-listings">Job Listings</h1>
+            </div>
+            <hr>
+            {% job_sponsors as grouped_sponsors %}
+            <div class="joblistings">
             {% for level_name, sponsors in grouped_sponsors %}
-                <h1>{{ level_name }} Sponsors</h1>
+                <div class="container center">
+                  <h2>{{ level_name }} Sponsors</h2>
+                </div>
                 <hr>
                 {% for sponsor in sponsors %}
-                    <h2 id="sponsor-{{ sponsor.id }}">{{ sponsor.name }}</h2>
-                    <a class="sponsor-logo" href="{{ sponsor.external_url }}">
-                        <img src="{% thumbnail sponsor.website_logo '150x80' %}" alt="{{ sponsor.name }}">
-                    </a>
-                    <p>
-                        <a href="{{ sponsor.external_url }}">{{ sponsor.get_display_url }}</a>
-                    </p>
-                    <div class="job-listing">{{ sponsor.joblisting_text|bleach }}</div>
-                    <hr>
+                  <h2 id="sponsor-{{ sponsor.id }}">{{ sponsor.name }}</h2>
+                  <a class="sponsor-logo" href="{{ sponsor.external_url }}">
+                    <img src="{% thumbnail sponsor.website_logo '150x80' %}" alt="{{ sponsor.name }}">
+                  </a>
+                  <p>
+                    <a href="{{ sponsor.external_url }}">{{ sponsor.get_display_url }}</a>
+                  </p>
+                  <div class="job-listing">{{ sponsor.joblisting_text|bleach }}</div>
+                  <hr>
                 {% endfor %}
             {% endfor %}
+            </div>
+          </div>
+          <div class="col-4">
+            <div class="container center">
+              <h3 id="job-fair-tables">Job Fair Directory</h3>
+            </div>
+            {% job_fair_participants as grouped_sponsors %}
+            <div class="jobfairparticpants container center">
+              <table>
+                <tr>
+                  <th>Sponsor</th>
+                  <th>Table #</th>
+                </tr>
+              {% for level_name, sponsors in grouped_sponsors %}
+                {% for sponsor in sponsors %}
+                <tr>
+                  <td><a href="{{ sponsor.external_url }}">{{ sponsor.name }}</a></td>
+                  <td>{{ sponsor.job_fair_table_number }}</td>
+                </tr>
+                {% endfor %}
+              {% endfor %}
+              </table>
+            </div>
+          </div>
+        </div>
     </div>
 {% endblock %}

--- a/pycon/templates/sponsorship/jobs.html
+++ b/pycon/templates/sponsorship/jobs.html
@@ -31,17 +31,17 @@
 
 {% block page_content %}
     <div class="container">
-        <div class="row">
-          <blockquote class="callout">
-            {% box "sponsor_jobs" %}
-          </blockquote>
-        </div>
         <div class="row hidden-lg" id="jobs-nav">
           <div class="container">
             <div class="row center">
                 <h4><a href="#job-fair-tables">Jump To Job Fair Directory</a></h4>
             </div>
           </div>
+        </div>
+        <div class="row">
+          <blockquote class="callout">
+            {% box "sponsor_jobs" %}
+          </blockquote>
         </div>
         <div class="row">
           <div class="col-8">


### PR DESCRIPTION
# Flag for Job Fair Participation

Added a `job_fair_participant` `BooleanField` on the `Sponsor` model and make editable in Django Admin.

<img width="396" alt="screen shot 2018-01-13 at 10 26 53 am" src="https://user-images.githubusercontent.com/1200832/34907431-62aa5470-f84c-11e7-8dab-c932419aee2a.png">

<img width="409" alt="screen shot 2018-01-13 at 10 26 34 am" src="https://user-images.githubusercontent.com/1200832/34907439-662e4e12-f84c-11e7-85bf-cb72410a1485.png">

# Auto generate Job Fair Participant/Table Listing
Dynamically generate an HTML table on the `sponsors/jobs` page with `Sponsor` name and their `job_fair_table_number` _if_ the `Sponsor` is a `job_fair_participant`.

<img width="1151" alt="screen shot 2018-01-13 at 10 19 32 am" src="https://user-images.githubusercontent.com/1200832/34907354-55334046-f84b-11e7-9fd8-09682c1b4ef8.png">

# Smarter Templates for Sponsor Emails

Added Django Template functionality to `Sponsor.send_email` that allows for Django Template logic in Sponsor email sends... Hard to explain 😢 

<img width="1151" alt="screen shot 2018-01-13 at 10 22 40 am" src="https://user-images.githubusercontent.com/1200832/34907385-c17dee2c-f84b-11e7-8d17-7fc32882cf67.png">

<img width="1151" alt="screen shot 2018-01-13 at 10 25 50 am" src="https://user-images.githubusercontent.com/1200832/34907422-35aeb25e-f84c-11e7-8acf-967acf3a7538.png">

Non Participant:

<img width="540" alt="screen shot 2018-01-13 at 10 28 40 am" src="https://user-images.githubusercontent.com/1200832/34907450-998b064c-f84c-11e7-8df0-88348ba73b23.png">

Participant:

<img width="485" alt="screen shot 2018-01-13 at 10 28 50 am" src="https://user-images.githubusercontent.com/1200832/34907452-9e22f296-f84c-11e7-904f-0dfd3632506b.png">


Address #643 #638 
