### PR TITLE
Update financial assistance page link in the financial aid application form

### DIFF
--- a/pycon/finaid/forms.py
+++ b/pycon/finaid/forms.py
@@ -16,7 +16,7 @@ def validate_is_checked(value):
 
 class FinancialAidApplicationForm(forms.ModelForm):
     i_have_read = forms.BooleanField(
-        label='I have read the <a href="/2018/financial-assistance/">Financial Assistance</a> page',
+        label='I have read the <a href="/2019/financial-assistance/">Financial Assistance</a> page',
         required=False,         # so our own validator gets called
         validators=[validate_is_checked],
     )


### PR DESCRIPTION
The link for the **I have read the Financial Assistance page** checkbox in the **Apply for Financial Aid** form still points to the 2018 financial assistance page.