### PR TITLE
updates for tutorial registrants and emails

### DIFF
--- a/pycon/management/commands/update_tutorial_registrants.py
+++ b/pycon/management/commands/update_tutorial_registrants.py
@@ -3,6 +3,7 @@ import logging
 import re
 import requests
 
+from account.models import EmailAddress
 from django.contrib.auth import get_user_model
 from django.core.management.base import NoArgsCommand
 
@@ -112,6 +113,10 @@ class Command(NoArgsCommand):
                                                                user_id))
                     continue
                 else:
+                    user_emails = EmailAddress.objects.filter(user=user)
+                    if user_email.lower() not in [e.email.lower() for e in user_emails]:
+                        logger.debug("Adding missing email {} to user {}".format(user_email, user_id))
+                        new_email = EmailAddress.objects.create(user=user, email=user_email)
                     tutorial.registrants.add(user)
                     logger.debug(
                         "Successfully registered '{}[{}]' for '{}' "

--- a/pycon/tests/test_commands.py
+++ b/pycon/tests/test_commands.py
@@ -152,4 +152,7 @@ class UpdateTutorialRegistrantsTestCase(TestCase):
         emails2 = EmailAddress.objects.filter(user=u2)
 
         self.assertEqual(['John@doe.com'], [e.email for e in emails1])
-        self.assertEqual(['jane@doe.com', 'jane.doe@gmail.com'], [e.email for e in emails2])
+        self.assertEqual(
+            sorted(['jane@doe.com', 'jane.doe@gmail.com']),
+            sorted([e.email for e in emails2])
+        )

--- a/pycon/tests/test_commands.py
+++ b/pycon/tests/test_commands.py
@@ -4,6 +4,8 @@ from mock import Mock, patch
 
 from requests.exceptions import HTTPError
 
+from account.models import EmailAddress
+
 from django.contrib.auth import get_user_model
 from django.core.management import call_command
 from django.test import TestCase
@@ -111,3 +113,43 @@ class UpdateTutorialRegistrantsTestCase(TestCase):
         # updated; dropping u2 and adding u1
         self.assertEqual(1, tut2.registrants.all().count())
         self.assertIn(u1, tut2.registrants.all())
+
+    def test_surprise_email_address(self, mock_get):
+        """Simple Test Case where registrant has a different email than our DB"""
+        user_model = get_user_model()
+        u1 = user_model.objects.create_user('john', email='John@doe.com', password='1234')
+        u2 = user_model.objects.create_user('jane', email='jane.doe@gmail.com', password='1234')
+
+        tut1 = PyConTutorialProposalFactory(title='Tutorial1')
+        PresentationFactory(proposal_base=tut1)
+        tut2 = PyConTutorialProposalFactory(title='Tutorial2')
+        PresentationFactory(proposal_base=tut2)
+
+        # Add u2 to tut2
+        tut2.registrants.add(u2)
+        self.assertIsNone(tut1.max_attendees)
+        self.assertIn(u2, tut2.registrants.all())
+
+        mock_get.return_value = MockGet(tut1=tut1.pk,
+                                        tut2=tut2.pk,
+                                        u1=u1.pk,
+                                        u2=u2.pk)
+        call_command('update_tutorial_registrants')
+
+        tut1 = PyConTutorialProposal.objects.get(pk=tut1.pk)
+        self.assertEqual(8, tut1.max_attendees)
+        self.assertEqual(2, tut1.registrants.all().count())
+        for u in [u1, u2]:
+            self.assertIn(u, tut1.registrants.all())
+
+        tut2 = PyConTutorialProposal.objects.get(pk=tut2.pk)
+        self.assertEqual(10, tut2.max_attendees)
+        # updated; dropping u2 and adding u1
+        self.assertEqual(1, tut2.registrants.all().count())
+        self.assertIn(u1, tut2.registrants.all())
+
+        emails1 = EmailAddress.objects.filter(user=u1)
+        emails2 = EmailAddress.objects.filter(user=u2)
+
+        self.assertEqual(['John@doe.com'], [e.email for e in emails1])
+        self.assertEqual(['jane@doe.com', 'jane.doe@gmail.com'], [e.email for e in emails2])

--- a/pycon/tutorials/views.py
+++ b/pycon/tutorials/views.py
@@ -2,6 +2,8 @@ import logging
 
 from smtplib import SMTPException
 
+from account.models import EmailAddress
+
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import get_user_model
@@ -34,7 +36,7 @@ def tutorial_email(request, pk, pks):
     pks = pks.split(",")
     user_model = get_user_model()
     recipients = user_model.objects.filter(pk__in=pks)
-    emails = recipients.values_list('email', flat=True)
+    emails = EmailAddress.objects.filter(user__in=recipients).values_list('email', flat=True)
 
     from_speaker = False
     if hasattr(request.user, 'speaker_profile'):


### PR DESCRIPTION
if the registration vendor returns an email we don't have in our DB for a user:
  - associate it in our database
  - send tutorial information to that address!