### PR TITLE
Redirect to secure_submission after submitting.

### DIFF
--- a/pycon/views.py
+++ b/pycon/views.py
@@ -201,7 +201,7 @@ def secure_submission(request):
             # Display a message to user
             messages.add_message(request, messages.INFO,
                                  "Secure Submission Accepted")
-            return redirect("dashboard")
+            return redirect("secure_submission")
 
     else:
         form = SecureSubmissionForm()


### PR DESCRIPTION
# problem
From tutorial offer letter I received the link to secure_submission where I can upload my docs (tax doc and payment info doc).
After submitting one document, I was redirected to dashboard, and could not find the secure submission form anywhere. I had to open up the offer letter again to find the link.

# proposed solution

I think it will be better if after submitting the form, people remained on the same page instead of getting redirected to dashboard. 